### PR TITLE
Modernise `run-tms-reco`

### DIFF
--- a/nersc/run-tms-reco/install_tms_reco.sh
+++ b/nersc/run-tms-reco/install_tms_reco.sh
@@ -6,8 +6,7 @@ rm -rf dune-tms
 
 ( git clone https://github.com/DUNE/dune-tms.git
   cd dune-tms || exit
-  # Tag from Jeff K.
-  git checkout tags/TMS_Reco_v0.2 
+  git checkout tags/nd-production-v01.00
   source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh 
   setup edepsim v3_2_0 -f Linux64bit+3.10-2.17 -q e20:prof 
   make )

--- a/nersc/util/init.inc.sh
+++ b/nersc/util/init.inc.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# NOTE: We assume that this script is "sourced" from e.g.
+# run-tms-reco/run_tms_reco.sh and that the current working directory is e.g.
+# run-tms-reco. Parent dir should be root of ND_Production/nersc.
+
+# The root of ND_Production/nersc:
+baseDir=$(realpath "$PWD"/..)
+
+# Start seeds at 1 instead of 0, just in case GENIE does something
+# weird when given zero (e.g. use the current time)
+seed=$((1 + ND_PRODUCTION_INDEX))
+echo "Seed is $seed"
+
+# NOTE: ND_PRODUCTION_INDEX is a "number" while globalIdx is the zero-padded string
+# representation of that number. Don't do math with globalIdx! Bash may parse it
+# as an octal number.
+
+globalIdx=$(printf "%07d" "$ND_PRODUCTION_INDEX")
+echo "globalIdx is $globalIdx"
+
+runOffset=${ND_PRODUCTION_RUN_OFFSET:-0}
+runNo=$((ND_PRODUCTION_INDEX + runOffset))
+echo "runNo is $runNo"
+
+# Default to the root of the ND_Production/nersc directoy (but ideally this should be set to
+# somewhere on $SCRATCH)
+ND_PRODUCTION_OUTDIR_BASE="${ND_PRODUCTION_OUTDIR_BASE:-$PWD/..}"
+mkdir -p "$ND_PRODUCTION_OUTDIR_BASE"
+ND_PRODUCTION_OUTDIR_BASE=$(realpath "$ND_PRODUCTION_OUTDIR_BASE")
+export ND_PRODUCTION_OUTDIR_BASE
+
+ND_PRODUCTION_LOGDIR_BASE="${ND_PRODUCTION_LOGDIR_BASE:-$PWD/..}"
+mkdir -p "$ND_PRODUCTION_LOGDIR_BASE"
+ND_PRODUCTION_LOGDIR_BASE=$(realpath "$ND_PRODUCTION_LOGDIR_BASE")
+export ND_PRODUCTION_LOGDIR_BASE
+
+# For "local" (i.e. non-container, non-CVMFS) installs of dune-tms etc.
+# Default to run-tms-reco etc.
+export ND_PRODUCTION_INSTALL_DIR=${ND_PRODUCTION_INSTALL_DIR:-$PWD}
+
+stepname=$(basename "$PWD")
+
+outDir=$ND_PRODUCTION_OUTDIR_BASE/${stepname}/$ND_PRODUCTION_OUT_NAME
+echo "outDir is $outDir"
+outName=$ND_PRODUCTION_OUT_NAME.$globalIdx
+echo "outName is $outName"
+mkdir -p "$outDir"
+
+tmpOutDir=$ND_PRODUCTION_OUTDIR_BASE/tmp/$stepname/$ND_PRODUCTION_OUT_NAME
+mkdir -p "$tmpOutDir"
+
+subDir=$(printf "%07d" $((ND_PRODUCTION_INDEX / 1000 * 1000)))
+
+logBase=$ND_PRODUCTION_LOGDIR_BASE/$stepname/$ND_PRODUCTION_OUT_NAME
+echo "logBase is $logBase"
+logDir=$logBase/LOGS/$subDir
+timeDir=$logBase/TIMING/$subDir
+mkdir -p "$logDir" "$timeDir"
+logFile=$logDir/$outName.log
+timeFile=$timeDir/$outName.time
+
+timeProg=/usr/bin/time
+# HACK in case we forget to include GNU time in a container
+[[ ! -e "$timeProg" ]] && timeProg=$PWD/../tmp_bin/time
+
+run() {
+    echo RUNNING "$@" | tee -a "$logFile"
+    time "$timeProg" --append -f "$1 %P %M %E" -o "$timeFile" "$@" 2>&1 | tee -a "$logFile"
+}
+
+libpath_remove() {
+  LD_LIBRARY_PATH=":$LD_LIBRARY_PATH:"
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH//":"/"::"}
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH//":$1:"/}
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH//"::"/":"}
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH#:}; LD_LIBRARY_PATH=${LD_LIBRARY_PATH%:}
+}

--- a/nersc/util/reload_in_container.inc.sh
+++ b/nersc/util/reload_in_container.inc.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Not currently used in ND_Production, will need it when 
+# things are fully ported from 2x2_sim.
+setup_cuda() {
+    module unload cudatoolkit 2>/dev/null
+    module load cudatoolkit/12.2
+}
+
+# Assume Shifter if ND_PRODUCTION_RUNTIME is unset.
+# (Individual scripts can override this; e.g. larnd-sim by default runs on the
+# host, not in Shifter)
+export ND_PRODUCTION_RUNTIME=${ND_PRODUCTION_RUNTIME:-SHIFTER}
+
+if [[ "$ND_PRODUCTION_RUNTIME" == "SHIFTER" ]]; then
+    # Reload in Shifter
+    if [[ "$SHIFTER_IMAGEREQUEST" != "$ND_PRODUCTION_CONTAINER" ]]; then
+        setup_cuda
+        shifter --image=$ND_PRODUCTION_CONTAINER --module=cvmfs,gpu -- "$0" "$@"
+        exit
+    fi
+
+elif [[ "$ND_PRODUCTION_RUNTIME" == "SINGULARITY" ]]; then
+    # Or reload in Singularity
+    if [[ "$SINGULARITY_NAME" != "$ND_PRODUCTION_CONTAINER" ]]; then
+        singularity exec -B $ND_PRODUCTION_DIR $ND_PRODUCTION_CONTAINER_DIR/$ND_PRODUCTION_CONTAINER /bin/bash "$0" "$@"
+        exit
+    fi
+
+elif [[ "$ND_PRODUCTION_RUNTIME" == "PODMAN-HPC" ]]; then
+    # The ND_Production/nersc directory:
+    nd_production_dir=$(realpath $(dirname "$BASH_SOURCE")/..)
+    # HACK: Check if we're "in podman" by seeing whether our UID is 0 (root)
+    # This will break if you run ND_Production as the true superuser, but why would
+    # you do that?
+    if [[ "$(id -u)" != "0" ]]; then
+        setup_cuda
+        podman-hpc run --rm --env-file <(env | grep ND_PRODUCTION) --gpu -w "$(realpath $(dirname "$0"))" \
+            -v "$nd_production_dir:$nd_production_dir" -v "$SCRATCH:$SCRATCH" -v /dvs_ro/cfs:/dvs_ro/cfs \
+            -v /opt/nvidia/hpc_sdk/Linux_x86_64/23.9:/opt/cuda \
+            "$ND_PRODUCTION_CONTAINER" "$(realpath "$0")" "$@"
+        exit
+    fi
+
+elif [[ "$ND_PRODUCTION_RUNTIME" == "NONE" ]]; then
+    echo "\$ND_PRODUCTION_RUNTIME is NONE; running in host environment"
+    return
+
+else
+    echo "Unsupported \$ND_PRODUCTION_RUNTIME"
+    exit 1
+fi
+
+# The below runs in the "reloaded" process
+
+if [[ "$ND_PRODUCTION_RUNTIME" == "SHIFTER" ]]; then
+    if [[ -e /environment ]]; then
+        source /environment # apptainer-built containters
+        # Our podman-built containers automagically load the env via $BASH_ENV
+        # In their case the file of interest is /opt/environment
+    fi
+    # See comments below re podman-hpc and cuda
+    cudadir=/global/common/software/dune/cuda-23.9
+    # TODO: Extend this until larnd-sim actually runs
+    export LD_LIBRARY_PATH="$cudadir"/math_libs/12.2/targets/x86_64-linux/lib:"$cudadir"/cuda/12.2/lib64:$LD_LIBRARY_PATH
+elif [[ "$ND_PRODUCTION_RUNTIME" == "PODMAN-HPC" ]]; then
+    # Ideally, we'd just tell podman-hpc to overlay the host's libcudart and
+    # libcudablas into the container's /usr/lib64, but that currently produces a
+    # useless error. So for now we just bind mount /opt/cuda (above) and set
+    # LD_LIBRARY_PATH here.
+    export LD_LIBRARY_PATH=/opt/cuda/math_libs/12.2/targets/x86_64-linux/lib:/opt/cuda/cuda/12.2/lib64:$LD_LIBRARY_PATH
+fi


### PR DESCRIPTION
Bringing `run-tms-reco` (and corresponding set up tools) in line with the rest of the NERSC production tools. The `dune-tms` tag in the install script is also updated to the one used in `MicroProdN1.2`.

These changes affect only `nersc` directory of this repository. If there are no objections in the next 24 hours from anyone I'll just go ahead and merge.