### PR TITLE
remove trailing comma for metadata

### DIFF
--- a/admin/dump_metadata.py
+++ b/admin/dump_metadata.py
@@ -200,7 +200,7 @@ def dump_metadata(datapath: Path, args: argparse.Namespace):
             'dune_mc.ND_Production.tag': get_current_git_branch(args.repo_ndprod) if args.repo_ndprod else 'nd-production-v02.01',
 
             'dune_mc.nu': args.nu,
-            'dune_mc.rock': not args.nu,
+            'dune_mc.rock': not args.nu
 
             # todo: we will need to return to this, once we can run this script WITHIN the nersc job...
             # 'cluster.gen_site': 'nersc',


### PR DESCRIPTION
Steve Timm was able to get to testing the metadata with the daemon -- we have an extra comma at the end. 

He also noted that there is some other missing field, he and CS+C is investigating and will get back to us. 