### PR TITLE
Added option to download GNU time if not present

### DIFF
--- a/admin/install_everything.sh
+++ b/admin/install_everything.sh
@@ -10,9 +10,9 @@ fi
 
 detector=$1
 
-pushd run-corsika
-./install_corsika.sh
-popd
+# pushd run-corsika
+# ./install_corsika.sh
+# popd
 
 # If using the ND_PRODUCTION_USE_GHEP_POT option, need to install a single
 # executable via install_hadd.sh.
@@ -20,27 +20,44 @@ pushd run-hadd
 ./install_hadd.sh
 popd
 
-pushd run-larnd-sim
-./install_larnd_sim.sh
-popd
+# pushd run-larnd-sim
+# ./install_larnd_sim.sh
+# popd
 
-pushd run-ndlar-flow
-./install_ndlar_flow.sh
-popd
+# pushd run-ndlar-flow
+# ./install_ndlar_flow.sh
+# popd
 
-pushd run-pandora
-./install_pandora.sh "$detector"
-popd
+# pushd run-pandora
+# ./install_pandora.sh "$detector"
+# popd
 
-pushd run-mlreco
-./install_mlreco.sh
-popd
+# pushd run-mlreco
+# ./install_mlreco.sh
+# popd
 
 pushd run-cafmaker
 ./install_cafmaker.sh
 popd
 
 # HACK because we forgot to include GNU time in some of the containers
-# Hope you have it on your host system!
-mkdir -p tmp_bin
-cp /usr/bin/time tmp_bin/
+TMP_BIN="tmp_bin"
+mkdir -p $TMP_BIN
+
+# If you have it on your host system (/usr/bin/time), copy it into tmp_bin directory
+# otherwise, download it from the link provided by Matt
+if [ -f /usr/bin/time ]; then
+  cp /usr/bin/time $TMP_BIN/
+else
+  # download the container-compatible version of GNU time into the right path
+  TIME_LINK="https://portal.nersc.gov/project/dune/data/2x2/people/mkramer/bin/time"
+  wget -q -O "$TMP_BIN/time" ${TIME_LINK} || {
+    echo "Download failed"
+    exit 1
+    } 
+    timeProg=$TMP_BIN/time
+    # check if "time" is executable
+    if [ ! -x $timeProg ]; then
+      chmod +x "$timeProg"
+    fi
+fi

--- a/admin/install_everything.sh
+++ b/admin/install_everything.sh
@@ -10,9 +10,9 @@ fi
 
 detector=$1
 
-# pushd run-corsika
-# ./install_corsika.sh
-# popd
+pushd run-corsika
+./install_corsika.sh
+popd
 
 # If using the ND_PRODUCTION_USE_GHEP_POT option, need to install a single
 # executable via install_hadd.sh.
@@ -20,21 +20,21 @@ pushd run-hadd
 ./install_hadd.sh
 popd
 
-# pushd run-larnd-sim
-# ./install_larnd_sim.sh
-# popd
+pushd run-larnd-sim
+./install_larnd_sim.sh
+popd
 
-# pushd run-ndlar-flow
-# ./install_ndlar_flow.sh
-# popd
+pushd run-ndlar-flow
+./install_ndlar_flow.sh
+popd
 
-# pushd run-pandora
-# ./install_pandora.sh "$detector"
-# popd
+pushd run-pandora
+./install_pandora.sh "$detector"
+popd
 
-# pushd run-mlreco
-# ./install_mlreco.sh
-# popd
+pushd run-mlreco
+./install_mlreco.sh
+popd
 
 pushd run-cafmaker
 ./install_cafmaker.sh

--- a/util/init.inc.sh
+++ b/util/init.inc.sh
@@ -64,29 +64,6 @@ timeProg=/usr/bin/time
 # HACK in case we forget to include GNU time in a container
 [[ ! -e "$timeProg" ]] && timeProg=$PWD/../tmp_bin/time
 
-# check if "time" file exists; if not, download it from the link provided by Matt
-if [ ! -f "$timeProg" ]; then
-  TMP_BIN="$ND_PRODUCTION_DIR/tmp_bin"
-
-  # check if TMP_BIN directory exists otherwise create it
-  if [ ! -d "$TMP_BIN" ]; then
-      mkdir -p "$TMP_BIN" || { echo "Failed to create $TMP_BIN"; exit 1; }
-  fi
-  
-  # download the container-compatible version of GNU time into the right path
-  TIME_LINK="https://portal.nersc.gov/project/dune/data/2x2/people/mkramer/bin/time"
-  wget -q -O "$TMP_BIN/time" ${TIME_LINK} || {
-    echo "Download failed"
-    exit 1
-    } 
-    timeProg=$TMP_BIN/time
-
-    # check if "time" is executable
-    if [ ! -x $timeProg ]; then
-      chmod +x "$timeProg"
-    fi
-fi
-
 run() {
     echo RUNNING "$@" | tee -a "$logFile"
     time "$timeProg" --append -f "$1 %P %M %E" -o "$timeFile" "$@" 2>&1 | tee -a "$logFile"

--- a/util/init.inc.sh
+++ b/util/init.inc.sh
@@ -64,6 +64,29 @@ timeProg=/usr/bin/time
 # HACK in case we forget to include GNU time in a container
 [[ ! -e "$timeProg" ]] && timeProg=$PWD/../tmp_bin/time
 
+# check if "time" file exists; if not, download it from the link provided by Matt
+if [ ! -f "$timeProg" ]; then
+  TMP_BIN="$ND_PRODUCTION_DIR/tmp_bin"
+
+  # check if TMP_BIN directory exists otherwise create it
+  if [ ! -d "$TMP_BIN" ]; then
+      mkdir -p "$TMP_BIN" || { echo "Failed to create $TMP_BIN"; exit 1; }
+  fi
+  
+  # download the container-compatible version of GNU time into the right path
+  TIME_LINK="https://portal.nersc.gov/project/dune/data/2x2/people/mkramer/bin/time"
+  wget -q -O "$TMP_BIN/time" ${TIME_LINK} || {
+    echo "Download failed"
+    exit 1
+    } 
+    timeProg=$TMP_BIN/time
+
+    # check if "time" is executable
+    if [ ! -x $timeProg ]; then
+      chmod +x "$timeProg"
+    fi
+fi
+
 run() {
     echo RUNNING "$@" | tee -a "$logFile"
     time "$timeProg" --append -f "$1 %P %M %E" -o "$timeFile" "$@" 2>&1 | tee -a "$logFile"


### PR DESCRIPTION
Modified util/init.inc.sh to download GNU time if it is not already present (as at CNAF, Italian INFN computing center). `time` is downloaded within `tmp_bin` directory, specifically created for this purpose.