### PR TITLE
Add POT Information to `edep-sim` Spill File

### DIFF
--- a/run-spill-build/overlaySinglesIntoSpillsSorted.C
+++ b/run-spill-build/overlaySinglesIntoSpillsSorted.C
@@ -291,9 +291,11 @@ void overlaySinglesIntoSpillsSorted(std::string inFileName1,
   p->Write();
   auto potps = new TParameter<double>("pot_per_spill", is_n_int_mode ? -1 : spillPOT);
   potps->Write();
-  auto pot1 = new TParameter<double>("pot1", inFile1POT);
+  const auto inFile1POT_used = inFile1POT * evt_it_1 / N_evts_1;
+  auto pot1 = new TParameter<double>("pot1", inFile1POT_used);
   pot1->Write();
-  auto pot2 = new TParameter<double>("pot2", inFile2POT);
+  const auto inFile2POT_used = inFile1POT * evt_it_2 / N_evts_2;
+  auto pot2 = new TParameter<double>("pot2", inFile2POT_used);
   pot2->Write();
 
   outFile->mkdir("DetSimPassThru");

--- a/run-spill-build/overlaySinglesIntoSpillsSorted.C
+++ b/run-spill-build/overlaySinglesIntoSpillsSorted.C
@@ -291,10 +291,10 @@ void overlaySinglesIntoSpillsSorted(std::string inFileName1,
   p->Write();
   auto potps = new TParameter<double>("pot_per_spill", is_n_int_mode ? -1 : spillPOT);
   potps->Write();
-  const auto inFile1POT_used = inFile1POT * evt_it_1 / N_evts_1;
+  const auto inFile1POT_used = N_evts_1 ? (inFile1POT * evt_it_1 / N_evts_1) : 0;
   auto pot1 = new TParameter<double>("pot1", inFile1POT_used);
   pot1->Write();
-  const auto inFile2POT_used = inFile2POT * evt_it_2 / N_evts_2;
+  const auto inFile2POT_used = N_evts_2 ? (inFile2POT * evt_it_2 / N_evts_2) : 0;
   auto pot2 = new TParameter<double>("pot2", inFile2POT_used);
   pot2->Write();
 

--- a/run-spill-build/overlaySinglesIntoSpillsSorted.C
+++ b/run-spill-build/overlaySinglesIntoSpillsSorted.C
@@ -289,6 +289,12 @@ void overlaySinglesIntoSpillsSorted(std::string inFileName1,
   event_spill_map->Write("event_spill_map", 1);
   auto p = new TParameter<double>("spillPeriod_s", spillPeriod_s);
   p->Write();
+  auto potps = new TParameter<double>("pot_per_spill", is_n_int_mode ? -1 : spillPOT);
+  potps->Write();
+  auto pot1 = new TParameter<double>("pot1", inFile1POT);
+  pot1->Write();
+  auto pot2 = new TParameter<double>("pot2", inFile2POT);
+  pot2->Write();
 
   outFile->mkdir("DetSimPassThru");
   outFile->cd("DetSimPassThru");

--- a/run-spill-build/overlaySinglesIntoSpillsSorted.C
+++ b/run-spill-build/overlaySinglesIntoSpillsSorted.C
@@ -294,7 +294,7 @@ void overlaySinglesIntoSpillsSorted(std::string inFileName1,
   const auto inFile1POT_used = inFile1POT * evt_it_1 / N_evts_1;
   auto pot1 = new TParameter<double>("pot1", inFile1POT_used);
   pot1->Write();
-  const auto inFile2POT_used = inFile1POT * evt_it_2 / N_evts_2;
+  const auto inFile2POT_used = inFile2POT * evt_it_2 / N_evts_2;
   auto pot2 = new TParameter<double>("pot2", inFile2POT_used);
   pot2->Write();
 


### PR DESCRIPTION
It would be nice to have POT information in the CAFs, this is a good first step. I thought about using more descriptive names for `pot1` and `pot2` but it's probably better to keep this general and in the CAFs, which is what analysers will actually be using, we'll only quote the lower one. When the spill builder "runs out" of events in either dataset 1 or dataset 2, the spill loop is broken.