### PR TITLE
Fixed nonzero exit status in environment file

### DIFF
--- a/admin/container_env.sim2x2_genie_edep.3_04_00.20230912.sif.sh
+++ b/admin/container_env.sim2x2_genie_edep.3_04_00.20230912.sif.sh
@@ -9,9 +9,9 @@
     cd ${ROOTSYS}/bin; source thisroot.sh; cd -
 
 
-    set +o errexit
+
     source scl_source enable devtoolset-7
-    set -o errexit
+
 
     export GEN_DIR=/opt/generators
     export GENIE=${GEN_DIR}/GENIE/R-3_04_00

--- a/admin/container_env.sim2x2_genie_edep.3_04_00.20230912.sif.sh
+++ b/admin/container_env.sim2x2_genie_edep.3_04_00.20230912.sif.sh
@@ -9,8 +9,9 @@
     cd ${ROOTSYS}/bin; source thisroot.sh; cd -
 
 
-
+    set +o errexit
     source scl_source enable devtoolset-7
+    set -o errexit
 
     export GEN_DIR=/opt/generators
     export GENIE=${GEN_DIR}/GENIE/R-3_04_00

--- a/util/reload_in_container.inc.sh
+++ b/util/reload_in_container.inc.sh
@@ -62,7 +62,9 @@ if [[ "$ND_PRODUCTION_RUNTIME" == "SHIFTER" ]]; then
     export LD_LIBRARY_PATH="$cudadir"/math_libs/12.2/targets/x86_64-linux/lib:"$cudadir"/cuda/12.2/lib64:$LD_LIBRARY_PATH
 elif [[ "$ND_PRODUCTION_RUNTIME" == "SINGULARITY" ]]; then
     # "singularity pull" overwrites /environment
+    set +o errexit
     source "$ND_PRODUCTION_DIR"/admin/container_env."$ND_PRODUCTION_CONTAINER".sh
+    set -o errexit
 elif [[ "$ND_PRODUCTION_RUNTIME" == "PODMAN-HPC" ]]; then
     # Ideally, we'd just tell podman-hpc to overlay the host's libcudart and
     # libcudablas into the container's /usr/lib64, but that currently produces a


### PR DESCRIPTION
Added `set +o errexit`/`set -o errexit` around `source scl_source enable devtoolset-7` in [this](https://github.com/DUNE/ND_Production/blob/main/admin/container_env.sim2x2_genie_edep.3_04_00.20230912.sif.sh) environment file to avoid a nonzero exit status when running with Singularity.