### PR TITLE
Updating `run-tms-reco`

### DIFF
--- a/run-tms-reco/run_tms_reco.sh
+++ b/run-tms-reco/run_tms_reco.sh
@@ -17,7 +17,9 @@ setup() {
 
 ###################################################################################
 
+set +o errexit
 setup
+set -o errexit
 
 # Must go after setup.
 source ../util/init.inc.sh

--- a/run-tms-reco/run_tms_reco.sh
+++ b/run-tms-reco/run_tms_reco.sh
@@ -43,7 +43,7 @@ echo "and"
 echo "  ${ND_PRODUCTION_TMSRECOREADOUT_OUTFILE}"
 
 
-run ConvertToTMSTree.exe "$inFile"
+run ${PWD}/dune-tms/bin/ConvertToTMSTree.exe "$inFile"
 
 
 tmsRecoOutDir=$outDir/TMSRECO/$subDir


### PR DESCRIPTION
This PR updates the path to the executable that gets run in the run script to line up with the new way team TMS do their builds. Also included is a piece of wizardry that I don't quite understand but stole from the CAFMaking step and happenned to get things working again after failed initial tests :)