### PR TITLE
Bump Container in `run-mlreco` Install Script

### DIFF
--- a/run-mlreco/install_mlreco.sh
+++ b/run-mlreco/install_mlreco.sh
@@ -5,7 +5,7 @@ export ND_PRODUCTION_RUNTIME=SHIFTER
 ## Above but with venv support:
 # export ND_PRODUCTION_CONTAINER=mjkramer/sim2x2:mlreco001
 # This is the one that Francois has actually been using:
-export ND_PRODUCTION_CONTAINER=deeplearnphysics/larcv2:ub2204-cu121-torch251-larndsim
+export ND_PRODUCTION_CONTAINER=deeplearnphysics/larcv2:ub2204-cu124-torch251-larndsim
 
 source ../util/reload_in_container.inc.sh
 


### PR DESCRIPTION
The default container inside the `run_spine.sh` script was recently updated [here](https://github.com/DUNE/ND_Production/commit/f1dbee9fb2086dac1548d0157d74b5dd2a5602db). Updating the container in the `install_mlreco.sh` script to line up.