### PR TITLE
Update name of `NDLAr` Active Volume in ND `edep` `mac` File

### DIFF
--- a/run-edep-sim/macros/dune-nd.mac
+++ b/run-edep-sim/macros/dune-nd.mac
@@ -10,7 +10,7 @@
 # This ensures that each hit segment in the LAr is only associated with one
 # trajectory. It must be run BEFORE /edep/update.
 # https://github.com/DUNE/2x2_sim/issues/20
-/edep/hitSeparation TPCActive_shape -1 mm
+/edep/hitSeparation volTPCActive -1 mm
 
 /edep/update
 


### PR DESCRIPTION
A little while ago the name of the active volume for NDLAr in the gdml was updated to be in line with 2x2. Reflecting this change here.