### PR TITLE
Bugfix: `run_convert2h5.sh` with `keep_all_dets`

### DIFF
--- a/run-convert2h5/run_convert2h5.sh
+++ b/run-convert2h5/run_convert2h5.sh
@@ -22,16 +22,14 @@ fi
 
 outFile=$tmpOutDir/${outName}.EDEPSIM.hdf5
 
+ARGS="--input_file $inFile --output_file $outFile"
+
 if [[ "$ND_PRODUCTION_KEEP_ALL_DETS" == "1" ]]; then
-    keepAllDets=--keep_all_dets
-else
-    keepAllDets=""
+    ARGS="$ARGS --keep_all_dets"
 fi
 
 if [[ "$ND_PRODUCTION_COSMIC_SIM" == "1" ]]; then
-    isCosmicSim=--is_cosmic_sim
-else
-    isCosmicSim=""
+    ARGS="$ARGS --is_cosmic_sim"
 fi
 
 # After going from ROOT 6.14.06 to 6.28.06, apparently we need to point CPATH to
@@ -39,7 +37,7 @@ fi
 # the container already.)
 export CPATH=$EDEPSIM/include/EDepSim:$CPATH
 
-run ./convert_edepsim_roottoh5.py --input_file "$inFile" --output_file "$outFile" "$keepAllDets" "$isCosmicSim"
+run ./convert_edepsim_roottoh5.py $ARGS
 
 h5OutDir=$outDir/EDEPSIM_H5/$subDir
 mkdir -p "$h5OutDir"


### PR DESCRIPTION
I noticed when running unrelated tests that the `--keep_all_dets` argument was in effect being ignored when calling the conversion script via `run_convert2h5.sh` when not using `--is_cosmic_sim`. The reason being that if not running cosmic sim, the `isCosmicSim` bash var was still making it to the python call as an empty space which `fire` was interpreting as providing a value for `--keep_all_dets`.