### PR TITLE
Save secondary energy deposit info at convert2h5

### DIFF
--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -552,12 +552,6 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                 segment[iHit]["tran_diff"] = 0
                 segment[iHit]["pixel_plane"] = 0
                 segment[iHit]["n_photons"] = 0
-               
-                #pdg = segment[iHit]["pdg_id"]
-                #dE_sec = hitSegment.GetSecondaryDeposit()
-                #dE = hitSegment.GetEnergyDeposit()
-                #if dE_sec > 0:
-                #  print("dE = ",dE,", dE secondary = ", dE_sec,", PDG ",pdg,"    --> diff= ",dE - dE_sec)
 
             segments_list.append(segment)
         trajectories_list.append(trajectories[:n_traj])


### PR DESCRIPTION
This saves secondary (ie, "non-ionizing") energy deposits at the convert2h5 stage. This is needed in order to properly correct the default energy deposits, which describes the _total_ energy loss of a particle along some track segment (both ionizing + non-ionizing contributions).  Also added is the starting and ending KE of each particle.