### PR TITLE
Option to add `ND_PRODUCTION_INDEX_OFFSET` 

### DIFF
--- a/run-spill-build/run_spill_build.sh
+++ b/run-spill-build/run_spill_build.sh
@@ -14,6 +14,8 @@ inBaseDir=$ND_PRODUCTION_OUTDIR_BASE/run-hadd
 nuInDir=$inBaseDir/$ND_PRODUCTION_NU_NAME
 rockInDir=$inBaseDir/$ND_PRODUCTION_ROCK_NAME
 
+[ -z "${ND_PRODUCTION_INDEX_OFFSET}" ] && export ND_PRODUCTION_INDEX_OFFSET=0
+
 if [[ "$ND_PRODUCTION_REUSE_ROCK" == "1" ]]; then
   nNuFiles=$(find $nuInDir/EDEPSIM -type f | wc -l)
   nRockFiles=$(find $rockInDir/EDEPSIM -type f | wc -l)
@@ -22,6 +24,7 @@ if [[ "$ND_PRODUCTION_REUSE_ROCK" == "1" ]]; then
   echo "The rock file reuse rate is $reuseRate"
 
   rockIdx=$((ND_PRODUCTION_INDEX % nRockFiles))
+  rockIdx=$((rockIdx + ND_PRODUCTION_INDEX_OFFSET))
   rockGlobalIdx=$(printf "%07d" "$rockIdx")
 
   rockName=$ND_PRODUCTION_ROCK_NAME.$rockGlobalIdx


### PR DESCRIPTION
For `MiniProdN5` we are trying out two different geometries where the file indices run from `A` to `B` for one and `B+1` to `C` for another.  The same is true for the corresponding rock files and the operation that selects a given rock file for a given spill file when reusing rock needs to know about this. We can add an offset. An analogous change also needs to be made in the `run-cafmaker` step but will cross that bridge when we get there.