### PR TITLE
Updates to flow2root for MiniRun6.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ slurm-*.out
 *.root
 *.exe
 tmp_bin
+.*.swp
+
+# Ignore dictionary files created by ROOT conversion script
+run-pandora/AutoDict*
+
+# Ignore files downloaded by 'install' script
+run-cafmaker/*sqlite*

--- a/run-pandora/run_flow2root.sh
+++ b/run-pandora/run_flow2root.sh
@@ -28,10 +28,8 @@ inFile=${ND_PRODUCTION_OUTDIR_BASE}/run-ndlar-flow/${ND_PRODUCTION_IN_NAME}/FLOW
 isData=1
 [ "${ND_PRODUCTION_PANDORA_INPUT_FORMAT}" ==  "SPMC" ] && isData=0
 
-# Use *prompt* hits for simulation until truth-matching
-# issues can be fully debugged. - Aug 20, 2025
-#isFinal=${ND_PRODUCTION_USE_FINAL_HITS:-1}
-isFinal=0
+# Switch on whether to use prompt of final/merged hits (defauls to final)
+isFinal=${ND_PRODUCTION_USE_FINAL_HITS:-1}
 
 # Convert input HDF5 file to ROOT
 source $ND_PRODUCTION_PANDORA_INSTALL/pandora.venv/bin/activate

--- a/run-pandora/run_flow2root.sh
+++ b/run-pandora/run_flow2root.sh
@@ -28,14 +28,20 @@ inFile=${ND_PRODUCTION_OUTDIR_BASE}/run-ndlar-flow/${ND_PRODUCTION_IN_NAME}/FLOW
 isData=1
 [ "${ND_PRODUCTION_PANDORA_INPUT_FORMAT}" ==  "SPMC" ] && isData=0
 
+# Use *prompt* hits for simulation until truth-matching
+# issues can be fully debugged. - Aug 20, 2025
+#isFinal=${ND_PRODUCTION_USE_FINAL_HITS:-1}
+isFinal=0
+
 # Convert input HDF5 file to ROOT
 source $ND_PRODUCTION_PANDORA_INSTALL/pandora.venv/bin/activate
-python3 $ND_PRODUCTION_PANDORA_INSTALL/LArRecoND/ndlarflow/h5_to_root_ndlarflow.py $inFile $isData $tmpOutDir
+python3 $ND_PRODUCTION_PANDORA_INSTALL/LArRecoND/ndlarflow/h5_to_root_ndlarflow.py $inFile $isData $isFinal ${tmpOutDir}/${inName}.tmp.root
+run root -l -q $ND_PRODUCTION_PANDORA_INSTALL/LArRecoND/ndlarflow/rootToRootConversion.C+\(true,\"${tmpOutDir}/${inName}.tmp.root\",\"${tmpOutDir}/${inName}.FLOW.hdf5_hits.root\"\)
 deactivate
 
 # Move ROOT file from tmpOutDir to output directory
 rootOutDir=$outDir/FLOW/$subDir
 mkdir -p "${rootOutDir}"
-rootFile=${rootOutDir}/${outName}.FLOW.hdf5_hits.root
 tmpRootFile=${tmpOutDir}/${inName}.FLOW.hdf5_hits.root
+rootFile=${rootOutDir}/${outName}.FLOW.hdf5_hits.root
 mv "${tmpRootFile}" "${rootFile}"

--- a/run-pandora/run_flow2root.sh
+++ b/run-pandora/run_flow2root.sh
@@ -28,7 +28,7 @@ inFile=${ND_PRODUCTION_OUTDIR_BASE}/run-ndlar-flow/${ND_PRODUCTION_IN_NAME}/FLOW
 isData=1
 [ "${ND_PRODUCTION_PANDORA_INPUT_FORMAT}" ==  "SPMC" ] && isData=0
 
-# Switch on whether to use prompt of final/merged hits (defauls to final)
+# Switch on whether to use prompt or final/merged hits (defaults to final)
 isFinal=${ND_PRODUCTION_USE_FINAL_HITS:-1}
 
 # Convert input HDF5 file to ROOT


### PR DESCRIPTION
Changes needed to the flow2root script for 2x2's MiniRun6.5 production: 
- `h5_to_root_ndlarflow.py` now takes 4 arguments, one of which is a flag telling it which types of hits to use (prompt vs "final")
- `rootToRootConversion.C` script is now run
