### PR TITLE
Update flow_validation.py fix a minor graphing bug 

### DIFF
--- a/run-validation/flow_validation.py
+++ b/run-validation/flow_validation.py
@@ -90,7 +90,7 @@ def main(flow_file, charge_only):
            plt.ylabel('Maximum Value')
            plt.title('Maximum Values vs. Channel IDs')
            plt.grid(True)
-           plt.xlim(0, 60)
+           plt.xlim(0, 64)
            output.savefig()  
            plt.close()    
 


### PR DESCRIPTION
There shall be 64 channels for light. Here it only displays 60. Although channel 63 and 62 are not used, but the current graph is skipping over 61 out of the graphing area.