### PR TITLE
Adapt `run-cafmaker` for `ND_CAFMaker` Build Migration

### DIFF
--- a/run-cafmaker/install_cafmaker.sh
+++ b/run-cafmaker/install_cafmaker.sh
@@ -13,10 +13,10 @@ cd install
 git clone -b main https://github.com/DUNE/ND_CAFMaker.git
 cd ND_CAFMaker
 
-./build_deps.sh
-source ndcaf_setup.sh
-make -j8
-
+#./build_deps.sh
+source ndcaf_setup.sh prof
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PWD}/install
+cmake --build build --target install
 cd ../..
 
 # Pre-compile

--- a/run-cafmaker/install_cafmaker.sh
+++ b/run-cafmaker/install_cafmaker.sh
@@ -14,7 +14,7 @@ git clone -b main https://github.com/DUNE/ND_CAFMaker.git
 cd ND_CAFMaker
 
 #./build_deps.sh
-source ndcaf_setup.sh prof
+source ndcaf_setup_deps.sh prof
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PWD}/install
 cmake --build build --target install
 cd ../..

--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -46,7 +46,7 @@ cat "$cfgFile"
 echo ""
 echo ===================
 
-run makeCAF "--fcl=$cfgFile"
+run install/ND_CAFMaker/install/bin/makeCAF "--fcl=$cfgFile"
 
 cafOutDir=$outDir/CAF/$subDir
 flatCafOutDir=$outDir/CAF.flat/$subDir


### PR DESCRIPTION
In `ND_CAFMaker` [PR 123](https://github.com/DUNE/ND_CAFMaker/pull/123) @slanzi00 has changed the build from make to cmake. The PR updates the `install_` and `run_` scripts to be ready for this change.

Have tested the new install works at NERSC, I haven't actually run the CAFMaker.