### PR TITLE
Updates from SPINE training production

### DIFF
--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -253,11 +253,17 @@ def updateHDF5File(output_file, trajectories, segments, vertices, genie_s, genie
                 ngenie_s = len(f['mc_stack'])
                 f['mc_stack'].resize((ngenie_s+len(genie_s),))
                 f['mc_stack'][ngenie_s:] = genie_s
+            else:
+                # larnd-sim expects either full or nonexistent MC datasets
+                # not empty ones
+                del f['mc_stack']
 
             if len(genie_h):
                 ngenie_h = len(f['mc_hdr'])
                 f['mc_hdr'].resize((ngenie_h+len(genie_h),))
                 f['mc_hdr'][ngenie_h:] = genie_h
+            else:
+                del f['mc_hdr']
 
 # Read a file and dump it.
 def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -256,14 +256,16 @@ def updateHDF5File(output_file, trajectories, segments, vertices, genie_s, genie
             else:
                 # larnd-sim expects either full or nonexistent MC datasets
                 # not empty ones
-                del f['mc_stack']
+                if 'mc_stack' in f:
+                    del f['mc_stack']
 
             if len(genie_h):
                 ngenie_h = len(f['mc_hdr'])
                 f['mc_hdr'].resize((ngenie_h+len(genie_h),))
                 f['mc_hdr'][ngenie_h:] = genie_h
             else:
-                del f['mc_hdr']
+                if 'mc_hdr' in f:
+                    del f['mc_hdr']
 
 # Read a file and dump it.
 def dump(input_file, output_file, is_cosmic_sim=False, is_mpvmpr=False, keep_all_dets=False):

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -395,7 +395,7 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
         # Count total number of vertices and trajectories
         n_traj = 0
         all_traj_ids = set()
-        traj_map = {}
+        trajMap = {}
 
         # Dump the primary vertices
         vertices = np.empty(len(event.Primaries), dtype=vertices_dtype)
@@ -454,7 +454,7 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                     trajectories[n_traj]["dist_travel"]+=(trajectory.Points[i].GetPosition()-trajectory.Points[i+1].GetPosition()).Vect().Mag()* edep2cm
 
                 all_traj_ids.add(trajectory.GetTrackId())
-                traj_map[trajectory.GetTrackId()] = n_traj
+                trajMap[trajectory.GetTrackId()] = n_traj
                 n_traj += 1
 
             else:
@@ -522,7 +522,7 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                                     for i in range(len(trajectory.Points)-1))
                             n_traj += 1
                             all_traj_ids.add(trajectory.GetTrackId())
-                            traj_map[trajectory.GetTrackId()] = n_traj
+                            trajMap[trajectory.GetTrackId()] = n_traj
                             if trajectories[n_traj-1]["parent_id"] == -1:
                                 break
                             else:
@@ -559,7 +559,7 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                 segment[iHit]["t0"] = (segment[iHit]["t0_start"] + segment[iHit]["t0_end"]) / 2.
                 segment[iHit]["t"] = 0
                 segment[iHit]["dEdx"] = hitSegment.GetEnergyDeposit() / dx if dx > 0 else 0
-                segment[iHit]["pdg_id"] = trajectories[traj_map[hitSegment.Contrib[0]]]["pdg_id"]
+                segment[iHit]["pdg_id"] = trajectories[trajMap[hitSegment.Contrib[0]]]["pdg_id"]
                 segment[iHit]["n_electrons"] = 0
                 segment[iHit]["long_diff"] = 0
                 segment[iHit]["tran_diff"] = 0

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -538,9 +538,9 @@ def dump(input_file, output_file, is_cosmic_sim=False, is_mpvmpr=False, keep_all
                                 sum((trajectory.Points[i].GetPosition()
                                      - trajectory.Points[i+1].GetPosition()).Vect().Mag()
                                     for i in range(len(trajectory.Points)-1))
-                            n_traj += 1
                             all_traj_ids.add(trajectory.GetTrackId())
                             trajMap[trajectory.GetTrackId()] = n_traj
+                            n_traj += 1
                             if trajectories[n_traj-1]["parent_id"] == -1:
                                 break
                             else:

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -394,6 +394,8 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
 
         # Count total number of vertices and trajectories
         n_traj = 0
+        all_traj_ids = set()
+        traj_map = {}
 
         # Dump the primary vertices
         vertices = np.empty(len(event.Primaries), dtype=vertices_dtype)
@@ -436,8 +438,8 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                 trajectories[n_traj]["pxyz_end"] = p_end #(end_pt.GetMomentum().X(), end_pt.GetMomentum().Y(), end_pt.GetMomentum().Z())
                 trajectories[n_traj]["xyz_start"] = (start_pt.GetPosition().X() * edep2cm, start_pt.GetPosition().Y() * edep2cm, start_pt.GetPosition().Z() * edep2cm)
                 trajectories[n_traj]["xyz_end"] = (end_pt.GetPosition().X() * edep2cm, end_pt.GetPosition().Y() * edep2cm, end_pt.GetPosition().Z() * edep2cm)
-                trajectories[n_traj]["E_start"] = np.sqrt(np.sum(np.square(p_start)) + mass**2)
-                trajectories[n_traj]["E_end"] = np.sqrt(np.sum(np.square(p_end)) + mass**2)
+                trajectories[n_traj]["E_start"] = sqrt(start_pt.GetMomentum().Mag2() + mass**2)
+                trajectories[n_traj]["E_end"] = sqrt(end_pt.GetMomentum().Mag2() + mass**2)
                 trajectories[n_traj]["KE_start"] = trajectories[n_traj]["E_start"] - mass;
                 trajectories[n_traj]["KE_end"] = trajectories[n_traj]["E_end"] - mass;
                 trajectories[n_traj]["t_start"] = start_pt.GetPosition().T() * edep2us
@@ -451,6 +453,8 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                 for i in range(len(trajectory.Points)-1):
                     trajectories[n_traj]["dist_travel"]+=(trajectory.Points[i].GetPosition()-trajectory.Points[i+1].GetPosition()).Vect().Mag()* edep2cm
 
+                all_traj_ids.add(trajectory.GetTrackId())
+                traj_map[trajectory.GetTrackId()] = n_traj
                 n_traj += 1
 
             else:
@@ -473,12 +477,12 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                     segment[iHit]["traj_id"] = hitSegment.Contrib[0]
                     segment[iHit]["file_traj_id"] = trackMap[hitSegment.Contrib[0]]
                     seg_traj_id = hitSegment.Contrib[0]
-                    if segment[iHit]["traj_id"] not in trajectories["traj_id"]:
+                    if segment[iHit]["traj_id"] not in all_traj_ids:
                         # Given event.Trajectories is ordered by traj_id (trajectory.GetTrackId())
                         trajectory = event.Trajectories[seg_traj_id]
                         # Trace back in the family tree
                         while trajectory.GetParentId() >= -1:
-                            if trajectory.GetTrackId() in trajectories["traj_id"]:
+                            if trajectory.GetTrackId() in all_traj_ids:
                                 if trajectory.GetParentId() == -1:
                                     break
                                 else:
@@ -503,8 +507,8 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                             trajectories[n_traj]["pxyz_end"] = p_end #(end_pt.GetMomentum().X(), end_pt.GetMomentum().Y(), end_pt.GetMomentum().Z())
                             trajectories[n_traj]["xyz_start"] = (start_pt.GetPosition().X() * edep2cm, start_pt.GetPosition().Y() * edep2cm, start_pt.GetPosition().Z() * edep2cm)
                             trajectories[n_traj]["xyz_end"] = (end_pt.GetPosition().X() * edep2cm, end_pt.GetPosition().Y() * edep2cm, end_pt.GetPosition().Z() * edep2cm)
-                            trajectories[n_traj]["E_start"] = np.sqrt(np.sum(np.square(p_start)) + mass**2)
-                            trajectories[n_traj]["E_end"] = np.sqrt(np.sum(np.square(p_end)) + mass**2)
+                            trajectories[n_traj]["E_start"] = sqrt(start_pt.GetMomentum().Mag2() + mass**2)
+                            trajectories[n_traj]["E_end"] = sqrt(end_pt.GetMomentum().Mag2() + mass**2)
                             trajectories[n_traj]["t_start"] = start_pt.GetPosition().T() * edep2us
                             trajectories[n_traj]["t_end"] = end_pt.GetPosition().T() * edep2us
                             trajectories[n_traj]["start_process"] = start_pt.GetProcess()
@@ -512,10 +516,13 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                             trajectories[n_traj]["end_process"] = end_pt.GetProcess()
                             trajectories[n_traj]["end_subprocess"] = end_pt.GetSubprocess()
                             trajectories[n_traj]["pdg_id"] = trajectory.GetPDGCode()
-                            trajectories[n_traj]["dist_travel"]=0
-                            for i in range(len(trajectory.Points)-1):
-                                trajectories[n_traj]["dist_travel"]+=(trajectory.Points[i].GetPosition()-trajectory.Points[i+1].GetPosition()).Vect().Mag()* edep2cm
+                            trajectories[n_traj]["dist_travel"] = edep2cm * \
+                                sum((trajectory.Points[i].GetPosition()
+                                     - trajectory.Points[i+1].GetPosition()).Vect().Mag()
+                                    for i in range(len(trajectory.Points)-1))
                             n_traj += 1
+                            all_traj_ids.add(trajectory.GetTrackId())
+                            traj_map[trajectory.GetTrackId()] = n_traj
                             if trajectories[n_traj-1]["parent_id"] == -1:
                                 break
                             else:
@@ -552,7 +559,7 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                 segment[iHit]["t0"] = (segment[iHit]["t0_start"] + segment[iHit]["t0_end"]) / 2.
                 segment[iHit]["t"] = 0
                 segment[iHit]["dEdx"] = hitSegment.GetEnergyDeposit() / dx if dx > 0 else 0
-                segment[iHit]["pdg_id"] = trajectories[trajectories["traj_id"]==hitSegment.Contrib[0]]["pdg_id"]
+                segment[iHit]["pdg_id"] = trajectories[traj_map[hitSegment.Contrib[0]]]["pdg_id"]
                 segment[iHit]["n_electrons"] = 0
                 segment[iHit]["long_diff"] = 0
                 segment[iHit]["tran_diff"] = 0

--- a/run-convert2h5/convert_edepsim_roottoh5.py
+++ b/run-convert2h5/convert_edepsim_roottoh5.py
@@ -266,7 +266,7 @@ def updateHDF5File(output_file, trajectories, segments, vertices, genie_s, genie
                 del f['mc_hdr']
 
 # Read a file and dump it.
-def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
+def dump(input_file, output_file, is_cosmic_sim=False, is_mpvmpr=False, keep_all_dets=False):
 
     """
     Script to convert edep-sim root output to an h5 file formatted in a way
@@ -396,13 +396,22 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
         n_traj = 0
         all_traj_ids = set()
         trajMap = {}
+        if is_mpvmpr:
+            vertexMap = {}
 
         # Dump the primary vertices
         vertices = np.empty(len(event.Primaries), dtype=vertices_dtype)
         for iVtx, primaryVertex in enumerate(event.Primaries):
             #printPrimaryVertex("PP", primaryVertex)
             vertices[iVtx]["event_id"] = spill_it
-            vertices[iVtx]["vertex_id"] = globalVertexID
+            # For MPV/MPR (the only(?) case where we have > 1 primary), keep the
+            # "local" vertex ID (since that's what the SPINE training expects)
+            if is_mpvmpr:
+                vertices[iVtx]["vertex_id"] = iVtx
+                for particle in primaryVertex.Particles:
+                    vertexMap[particle.GetTrackId()] = iVtx
+            else:
+                vertices[iVtx]["vertex_id"] = globalVertexID
             vertices[iVtx]["x_vert"] = primaryVertex.GetPosition().X() * edep2cm
             vertices[iVtx]["y_vert"] = primaryVertex.GetPosition().Y() * edep2cm
             vertices[iVtx]["z_vert"] = primaryVertex.GetPosition().Z() * edep2cm
@@ -423,7 +432,10 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
             if trajectory.GetParentId() == -1:
                 start_pt, end_pt = trajectory.Points[0], trajectory.Points[-1]
                 trajectories[n_traj]["event_id"] = spill_it
-                trajectories[n_traj]["vertex_id"] = globalVertexID
+                if is_mpvmpr:
+                    trajectories[n_traj]["vertex_id"] = vertexMap[trajectory.GetTrackId()]
+                else:
+                    trajectories[n_traj]["vertex_id"] = globalVertexID
 
                 trajectories[n_traj]["traj_id"] = trajectory.GetTrackId()
                 trajectories[n_traj]["file_traj_id"] = trackMap[trajectory.GetTrackId()]
@@ -458,6 +470,8 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                 n_traj += 1
 
             else:
+                if is_mpvmpr:
+                    vertexMap[trajectory.GetTrackId()] = vertexMap[trajectory.GetParentId()]
                 continue
 
         # Dump the segment containers
@@ -470,7 +484,10 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
             segment = np.empty(len(hitSegments), dtype=segments_dtype)
             for iHit, hitSegment in enumerate(hitSegments):
                 segment[iHit]["event_id"] = spill_it
-                segment[iHit]["vertex_id"] = globalVertexID
+                if is_mpvmpr:
+                    segment[iHit]["vertex_id"] = vertexMap[hitSegment.Contrib[0]]
+                else:
+                    segment[iHit]["vertex_id"] = globalVertexID
                 segment[iHit]["segment_id"] = segment_id
                 segment_id += 1
                 try:
@@ -482,6 +499,7 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
                         trajectory = event.Trajectories[seg_traj_id]
                         # Trace back in the family tree
                         while trajectory.GetParentId() >= -1:
+                            # Skip (and continue tracing) if traj was already seen
                             if trajectory.GetTrackId() in all_traj_ids:
                                 if trajectory.GetParentId() == -1:
                                     break
@@ -492,7 +510,7 @@ def dump(input_file, output_file, is_cosmic_sim=False, keep_all_dets=False):
 
                             start_pt, end_pt = trajectory.Points[0], trajectory.Points[-1]
                             trajectories[n_traj]["event_id"] = spill_it
-                            trajectories[n_traj]["vertex_id"] = globalVertexID
+                            trajectories[n_traj]["vertex_id"] = segment[iHit]["vertex_id"]
 
                             trajectories[n_traj]["traj_id"] = trajectory.GetTrackId()
                             trajectories[n_traj]["file_traj_id"] = trackMap[trajectory.GetTrackId()]

--- a/run-convert2h5/run_convert2h5.sh
+++ b/run-convert2h5/run_convert2h5.sh
@@ -32,6 +32,10 @@ if [[ "$ND_PRODUCTION_COSMIC_SIM" == "1" ]]; then
     ARGS="$ARGS --is_cosmic_sim"
 fi
 
+if [[ "$ND_PRODUCTION_IS_MPVMPR" == "1" ]]; then
+    ARGS="$ARGS --is_mpvmpr"
+fi
+
 # After going from ROOT 6.14.06 to 6.28.06, apparently we need to point CPATH to
 # the edepsim-io headers. Otherwise convert2h5 fails. (This "should" be set in
 # the container already.)

--- a/run-edep-sim/macros/dune-nd.bomb.mac
+++ b/run-edep-sim/macros/dune-nd.bomb.mac
@@ -16,7 +16,10 @@
 /edep/update
 
 /generator/kinematics/set bomb
-/generator/kinematics/bomb/config mpvmpr/mpvmpr_nd.yaml
+
+## Now controlled by ND_PRODUCTION_MPVMPR_CONFIG
+# /generator/kinematics/bomb/config mpvmpr/mpvmpr_nd.yaml
+
 /generator/position/set free
 /generator/time/set free
 /generator/count/fixed/number 1

--- a/run-edep-sim/macros/dune-nd.bomb.mac
+++ b/run-edep-sim/macros/dune-nd.bomb.mac
@@ -1,0 +1,24 @@
+## Physics changes
+
+## Not everything is LAr
+/edep/phys/ionizationModel 0
+
+/edep/hitSeparation volTPCActive -1 mm
+/edep/hitSagitta drift 1.0 mm
+/edep/hitLength drift 1.0 mm
+
+/edep/db/set/neutronThreshold 0 MeV
+/edep/db/set/lengthThreshold 0 mm
+/edep/db/set/gammaThreshold 0 MeV
+
+/edep/random/timeRandomSeed
+
+/edep/update
+
+/generator/kinematics/set bomb
+/generator/kinematics/bomb/config mpvmpr/mpvmpr_nd.yaml
+/generator/position/set free
+/generator/time/set free
+/generator/count/fixed/number 1
+/generator/count/set fixed
+/generator/add

--- a/run-edep-sim/mpvmpr/mpvmpr_nd.yaml
+++ b/run-edep-sim/mpvmpr/mpvmpr_nd.yaml
@@ -1,0 +1,166 @@
+# ===============
+# mpvmpr_cfg.yaml
+# ===============
+
+
+SEED: -1
+## with lepton, generate 20cm from the wall
+## the KE range is ~80% coverage of the LBNF
+Generator1:
+  NumEvent: [5,15]
+  NumParticle: [1,10]
+  XRange: [-3700, 3700] #mm
+  YRange: [-2368.713, 1031.287] #mm
+  ZRange: [3957.559, 9357.559] #mm
+  TRange: [0,10000] #ns
+  AddParent: True
+  Particles:
+    -
+      PDG:      [11,-11,13,-13]
+      NumRange: [1,1]
+      KERange:  [0.01,5.] # 3.1 for muons and 7.3 for electrons
+      UseMom:   False
+      Weight:   1
+    -
+      PDG:      [211,-211]
+      NumRange: [0,2]
+      KERange:  [0.01,1.1]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [22,111]
+      NumRange: [0,2]
+      KERange:  [0.01,1.1] # 0.7 for 22, 1.1 for 111
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [2212]
+      NumRange: [0,5]
+      KERange:  [0.02,0.2]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [2112]
+      NumRange: [0,3]
+      KERange:  [0.02,0.2]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [130, 321, -321, 310]
+      NumRange: [0,1]
+      KERange:  [0.01,4.]
+      UseMom:   False
+      Weight:   0.25
+
+    -
+      PDG:      [3122]
+      NumRange: [0,1]
+      KERange:  [0.01,2.1]
+      UseMom:   False
+      Weight:   0.25
+
+# NC
+Generator2:
+  NumEvent: [3,7]
+  NumParticle: [1,9]
+  XRange: [-3700, 3700] #mm
+  YRange: [-2368.713, 1031.287] #mm
+  ZRange: [3957.559, 9357.559] #mm
+  TRange: [0,10000] #ns
+  AddParent: True
+  Particles:
+    -
+      PDG:      [211,-211]
+      NumRange: [0,2]
+      KERange:  [0.01,1.1]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [22,111]
+      NumRange: [0,2]
+      KERange:  [0.01,1.1] # 0.7 for 22, 1.1 for 111
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [2212]
+      NumRange: [0,4]
+      KERange:  [0.02,0.2]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [2112]
+      NumRange: [0,3]
+      KERange:  [0.02,0.2]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:      [130, 321, -321, 310]
+      NumRange: [0,1]
+      KERange:  [0.01,4.]
+      UseMom:   False
+      Weight:   0.25
+
+    -
+      PDG:      [3122]
+      NumRange: [0,1]
+      KERange:  [0.01,2.1]
+      UseMom:   False
+      Weight:   0.25
+
+Singles:
+  NumEvent: [30,50]
+  NumParticle: [1,1]
+  XRange: [-3700, 3700] #mm
+  YRange: [-2368.713, 1031.287] #mm
+  ZRange: [3957.559, 9357.559] #mm
+  TRange: [0,10000] #ns
+  Particles:
+    -
+      PDG:  [13, -13]
+      NumRange: [0,30]
+      KERange:  [0.05,6.]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:  [-13]
+      NumRange: [0,20]
+      KERange:  [0.1,0.5]
+      UseMom:   False
+      Weight:   1
+
+    -
+      PDG:  [22]
+      NumRange: [0,1]
+      KERange:  [0.01,1.]
+      UseMom:   False
+      Weight:   0.5
+
+    -
+      PDG:  [211,-211]
+      NumRange: [0,1]
+      KERange:  [0.05,1.]
+      UseMom:   False
+      Weight:   0.5
+
+    -
+      PDG:  [2212]
+      NumRange: [0,1]
+      KERange:  [0.05,0.4]
+      UseMom:   False
+      Weight:   0.5
+
+    -
+      PDG:  [2112]
+      NumRange: [0,5]
+      KERange:  [0.05,0.4]
+      UseMom:   False
+      Weight:   0.25

--- a/run-edep-sim/mpvmpr/mpvmpr_nd.yaml
+++ b/run-edep-sim/mpvmpr/mpvmpr_nd.yaml
@@ -2,10 +2,19 @@
 # mpvmpr_cfg.yaml
 # ===============
 
-
+## Used MiniProdN5p2 Genie GTRAC (fiducial LAr)
+## - Uniform directions
+## - KE range covers >80% of LBNF
+## - Multiplicity range covers >80% of LBNF
+## - The generation volume includes ~20 cm padding around the detector boundaries
+##
+## Detector boundaries:
+## X: [-346.788 ,  346.788 ]
+## Y: [-215.6713,   81.9287]
+## Z: [ 418.1399,  913.3719]
 SEED: -1
-## with lepton, generate 20cm from the wall
-## the KE range is ~80% coverage of the LBNF
+
+# CC (with lepton)
 Generator1:
   NumEvent: [5,15]
   NumParticle: [1,10]
@@ -18,52 +27,52 @@ Generator1:
     -
       PDG:      [11,-11,13,-13]
       NumRange: [1,1]
-      KERange:  [0.01,5.] # 3.1 for muons and 7.3 for electrons
+      KERange:  [0.01,15.0] # 12.6 for muons and 12.3 for electrons
       UseMom:   False
       Weight:   1
     -
       PDG:      [211,-211]
       NumRange: [0,2]
-      KERange:  [0.01,1.1]
+      KERange:  [0.01,2.5] # 2.1 for 211
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [22,111]
       NumRange: [0,2]
-      KERange:  [0.01,1.1] # 0.7 for 22, 1.1 for 111
+      KERange:  [0.01,2.5] # 2.0 for 22, 1.7 for 111
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [2212]
       NumRange: [0,5]
-      KERange:  [0.02,0.2]
+      KERange:  [0.02,1.0] # 0.7 for 2212
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [2112]
       NumRange: [0,3]
-      KERange:  [0.02,0.2]
+      KERange:  [0.02,1.0] # 0.6 for 2112
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [130, 321, -321, 310]
       NumRange: [0,1]
-      KERange:  [0.01,4.]
+      KERange:  [0.01,5.0] # 4.4 for 130, 4.5 for 321, no 310?
       UseMom:   False
       Weight:   0.25
 
     -
       PDG:      [3122]
       NumRange: [0,1]
-      KERange:  [0.01,2.1]
+      KERange:  [0.01,3.0] # 2.4 for 3122
       UseMom:   False
       Weight:   0.25
 
-# NC
+# NC (no lepton)
 Generator2:
   NumEvent: [3,7]
   NumParticle: [1,9]
@@ -76,42 +85,42 @@ Generator2:
     -
       PDG:      [211,-211]
       NumRange: [0,2]
-      KERange:  [0.01,1.1]
+      KERange:  [0.01,2.5] # 2.1 for 211
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [22,111]
       NumRange: [0,2]
-      KERange:  [0.01,1.1] # 0.7 for 22, 1.1 for 111
+      KERange:  [0.01,2.5] # 2.0 for 22, 1.7 for 111
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [2212]
-      NumRange: [0,4]
-      KERange:  [0.02,0.2]
+      NumRange: [0,5]
+      KERange:  [0.02,1.0] # 0.7 for 2212
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [2112]
       NumRange: [0,3]
-      KERange:  [0.02,0.2]
+      KERange:  [0.02,1.0] # 0.6 for 2112
       UseMom:   False
       Weight:   1
 
     -
       PDG:      [130, 321, -321, 310]
       NumRange: [0,1]
-      KERange:  [0.01,4.]
+      KERange:  [0.01,5.0] # 4.4 for 130, 4.5 for 321, no 310?
       UseMom:   False
       Weight:   0.25
 
     -
       PDG:      [3122]
       NumRange: [0,1]
-      KERange:  [0.01,2.1]
+      KERange:  [0.01,3.0] # 2.4 for 3122
       UseMom:   False
       Weight:   0.25
 
@@ -126,41 +135,48 @@ Singles:
     -
       PDG:  [13, -13]
       NumRange: [0,30]
-      KERange:  [0.05,6.]
+      KERange:  [0.1,15.0] # 12.6 for muons
       UseMom:   False
       Weight:   1
 
     -
       PDG:  [-13]
       NumRange: [0,20]
-      KERange:  [0.1,0.5]
+      KERange:  [0.1,0.5] # To enhance Michel sample (decaying antimuons)
       UseMom:   False
       Weight:   1
 
     -
+      PDG:  [11, -11]
+      NumRange: [0,1]
+      KERange:  [0.1,15.0] # 12.3 for electrons
+      UseMom:   False
+      Weight:   0.5
+
+    -
       PDG:  [22]
       NumRange: [0,1]
-      KERange:  [0.01,1.]
+      KERange:  [0.1,2.5] # 2.0 for 22
       UseMom:   False
       Weight:   0.5
 
     -
       PDG:  [211,-211]
       NumRange: [0,1]
-      KERange:  [0.05,1.]
+      KERange:  [0.1,2.5] # 2.1 for 211
       UseMom:   False
       Weight:   0.5
 
     -
       PDG:  [2212]
       NumRange: [0,1]
-      KERange:  [0.05,0.4]
+      KERange:  [0.1,1.0] # 0.7 for 2212
       UseMom:   False
       Weight:   0.5
 
     -
       PDG:  [2112]
-      NumRange: [0,5]
-      KERange:  [0.05,0.4]
+      NumRange: [0,3]
+      KERange:  [0.1,1.0] # 0.6 for 2112
       UseMom:   False
       Weight:   0.25

--- a/run-edep-sim/run_edep_sim.sh
+++ b/run-edep-sim/run_edep_sim.sh
@@ -38,6 +38,9 @@ else
         exit 1
     fi
     nEvents=$ND_PRODUCTION_NUM_EVENTS
+    if [[ -n "$ND_PRODUCTION_MPVMPR_CONFIG" ]]; then
+        edepCode+=("/generator/kinematics/bomb/config $ND_PRODUCTION_MPVMPR_CONFIG")
+    fi
 fi
 
 edepRootFile=$tmpOutDir/${outName}.EDEPSIM.root

--- a/run-edep-sim/run_edep_sim.sh
+++ b/run-edep-sim/run_edep_sim.sh
@@ -48,7 +48,7 @@ rm -f "$edepRootFile"
 
 edepCode+=("/edep/runId $runNo")
 
-# The geometry file is given relative to the root of 2x2_sim
+# The geometry file is given relative to the root of ND_Production
 export ND_PRODUCTION_GEOM_EDEP=$baseDir/${ND_PRODUCTION_GEOM_EDEP:-$ND_PRODUCTION_GEOM}
 
 run edep-sim -C -g "$ND_PRODUCTION_GEOM_EDEP" -o "$edepRootFile" -e "$nEvents" \

--- a/run-edep-sim/run_edep_sim.sh
+++ b/run-edep-sim/run_edep_sim.sh
@@ -15,28 +15,41 @@ elif [[ "$simulation" == "CORSIKA" ]]; then
     inputPrefix=${ND_PRODUCTION_OUTDIR_BASE}/run-corsika/${ND_PRODUCTION_CORSIKA_NAME}/CORSIKA/$subDir/${ND_PRODUCTION_CORSIKA_NAME}.$globalIdx
     inputFile=$inputPrefix.CORSIKA.root
 
+elif [[ "$simulation" == "BOMB" ]]; then
+    : # no input file, nothing to do here
+
 else
     echo "Unsupported \$ND_PRODUCTION_SIM type. Exiting."
     echo "\$ND_PRODUCTION_SIM = ${ND_PRODUCTION_SIM}"
     exit 1
 fi
 
-rootCode='
-auto t = (TTree*) _file0->Get("gRooTracker");
-std::cout << t->GetEntries() << std::endl;'
-nEvents=$(echo "$rootCode" | root -l -b "$inputFile" | tail -1)
+edepCode=()
+
+if [[ -n "$inputFile" ]]; then
+    edepCode+=("/generator/kinematics/rooTracker/input $inputFile")
+    rootCode='
+    auto t = (TTree*) _file0->Get("gRooTracker");
+    std::cout << t->GetEntries() << std::endl;'
+    nEvents=$(echo "$rootCode" | root -l -b "$inputFile" | tail -1)
+else
+    if [[ -z "$ND_PRODUCTION_NUM_EVENTS" ]]; then
+        echo "Please set \$ND_PRODUCTION_NUM_EVENTS"
+        exit 1
+    fi
+    nEvents=$ND_PRODUCTION_NUM_EVENTS
+fi
 
 edepRootFile=$tmpOutDir/${outName}.EDEPSIM.root
 rm -f "$edepRootFile"
 
-edepCode="/generator/kinematics/rooTracker/input $inputFile
-/edep/runId $runNo"
+edepCode+=("/edep/runId $runNo")
 
 # The geometry file is given relative to the root of 2x2_sim
 export ND_PRODUCTION_GEOM_EDEP=$baseDir/${ND_PRODUCTION_GEOM_EDEP:-$ND_PRODUCTION_GEOM}
 
 run edep-sim -C -g "$ND_PRODUCTION_GEOM_EDEP" -o "$edepRootFile" -e "$nEvents" \
-    <(echo "$edepCode") "$ND_PRODUCTION_EDEP_MAC"
+    <(printf "%s\n" "${edepCode[@]}") "$ND_PRODUCTION_EDEP_MAC"
 
 mkdir -p "$outDir/EDEPSIM/$subDir"
 mv "$edepRootFile" "$outDir/EDEPSIM/$subDir"

--- a/run-mlreco/install_mlreco.sh
+++ b/run-mlreco/install_mlreco.sh
@@ -48,7 +48,7 @@ source configure.sh
 make -j16
 cd ..
 
-git clone -b v1.8.0 https://github.com/DeepLearnPhysics/SuperaAtomic.git
+git clone -b v1.9.0 https://github.com/DeepLearnPhysics/SuperaAtomic.git
 
 cd SuperaAtomic
 git submodule update --init     # pybind11

--- a/run-ndlar-flow/run_ndlar_flow_ndlar.sh
+++ b/run-ndlar-flow/run_ndlar_flow_ndlar.sh
@@ -29,19 +29,21 @@ if [[ "$ND_PRODUCTION_COMPRESS" != "" ]]; then
     compression="-z $ND_PRODUCTION_COMPRESS"
 fi
 
+yamldir=${ND_PRODUCTION_YAML_DIR:-ndlar_flow}
+
 # charge workflows
-workflow1='yamls/ndlar_flow/workflows/charge/charge_event_building_mc.yaml'
-workflow2='yamls/ndlar_flow/workflows/charge/charge_event_reconstruction_mc.yaml'
-workflow3='yamls/ndlar_flow/workflows/combined/combined_reconstruction_mc.yaml'
-workflow4='yamls/ndlar_flow/workflows/charge/prompt_calibration_mc.yaml'
-workflow5='yamls/ndlar_flow/workflows/charge/final_calibration_mc.yaml'
+workflow1="yamls/$yamldir/workflows/charge/charge_event_building_mc.yaml"
+workflow2="yamls/$yamldir/workflows/charge/charge_event_reconstruction_mc.yaml"
+workflow3="yamls/$yamldir/workflows/combined/combined_reconstruction_mc.yaml"
+workflow4="yamls/$yamldir/workflows/charge/prompt_calibration_mc.yaml"
+workflow5="yamls/$yamldir/workflows/charge/final_calibration_mc.yaml"
 
 # light workflows
-workflow6='yamls/ndlar_flow/workflows/light/light_event_building_mc.yaml'
-workflow7='yamls/ndlar_flow/workflows/light/light_event_reconstruction_mc.yaml'
+workflow6="yamls/$yamldir/workflows/light/light_event_building_mc.yaml"
+workflow7="yamls/$yamldir/workflows/light/light_event_reconstruction_mc.yaml"
 
 # charge-light trigger matching
-workflow8='yamls/ndlar_flow/workflows/charge/charge_light_assoc_mc.yaml'
+workflow8="yamls/$yamldir/workflows/charge/charge_light_assoc_mc.yaml"
 
 cd "$ND_PRODUCTION_INSTALL_DIR"/ndlar_flow
 

--- a/run-ndlar-flow/run_ndlar_flow_ndlar.sh
+++ b/run-ndlar-flow/run_ndlar_flow_ndlar.sh
@@ -52,11 +52,12 @@ set -o errexit
 run h5flow -c $workflow1 $workflow2 $workflow3 $workflow4 $workflow5\
     -i "$inFile" -o "$outFile" $compression
 
-run h5flow -c $workflow6 $workflow7\
-    -i "$inFile" -o "$outFile" $compression
-
-run h5flow -c $workflow8\
-    -i "$outFile" -o "$outFile" $compression
+if [[ -z "$ND_PRODUCTION_CHARGE_ONLY" || "$ND_PRODUCTION_CHARGE_ONLY" == "0" ]]; then
+    run h5flow -c $workflow6 $workflow7\
+        -i "$inFile" -o "$outFile" $compression
+    run h5flow -c $workflow8\
+        -i "$outFile" -o "$outFile" $compression
+fi
 
 mkdir -p "$outDir/FLOW/$subDir"
 mv "$outFile" "$outDir/FLOW/$subDir"


### PR DESCRIPTION
This PR collects all of the changes made for the production of the recent SPINE training sample:

- Updated `run_edep_sim.sh` to support a new `ND_PRODUCTION_SIMULATION` option `BOMB` along with new associated settings `ND_PRODUCTION_NUM_EVENTS` and `ND_PRODUCTION_MPVMPR_CONFIG`
- Added the corresponding Geant4 macro `dune-nd.bomb.mac`
- Added the MPV/MPR configuration `mpvmpr_nd.yaml` used for this sample
- Updated convert2h5 to support MPV/MPR and to run a bit faster more generally. Backward compatibility confirmed by using this version to process MiniProdN5 spills.
- Bumped SuperaAtomic to v1.9.0 in `install_mlreco.sh`
- Added support for `ND_PRODUCTION_CHARGE_ONLY` to `run_ndlar_flow_ndlar.sh`. Also added the `ND_PRODUCTION_YAML_DIR` variable which allows this script to be used for the 2x2 and FSD as well. De-duplication with the other two (now largely redundant) scripts postponed to a future PR.