### PR TITLE
Add simplified SPINE script for modern `spine-prod` configs

### DIFF
--- a/run-mlreco/install_mlreco.sh
+++ b/run-mlreco/install_mlreco.sh
@@ -100,4 +100,7 @@ git clone -b develop https://github.com/DeepLearnPhysics/spine.git
 # sed -i 's/yaml.load(open(filename))/yaml.load(open(filename), yaml.Loader)/' \
 #     dune-nd-lar-reco/load_helpers.py
 
-git clone -b main https://github.com/DeepLearnPhysics/spine_prod.git
+git clone -b main https://github.com/DeepLearnPhysics/spine-prod.git
+
+# for backward-compatibility with run_mlreco.spine.sh
+ln -s spine-prod spine_prod

--- a/run-mlreco/run_spine.spine-prod.sh
+++ b/run-mlreco/run_spine.spine-prod.sh
@@ -16,12 +16,10 @@ outFile=${tmpOutDir}/${outName}.MLRECO_SPINE.hdf5
 inName=${ND_PRODUCTION_IN_NAME}.${globalIdx}
 inFile=${ND_PRODUCTION_OUTDIR_BASE}/run-mlreco/${ND_PRODUCTION_IN_NAME}/LARCV/${subDir}/${inName}.LARCV.root
 
+rm -f "$outFile"
+
 source install/spine-prod/configure.sh
 
-# spine does something interesting with the output filename
-actualOutFile=${tmpOutDir}/${inName}.LARCV_$(basename "$outFile" .hdf5).h5
-
-rm -f "$actualOutFile"
 
 run python3 install/spine/bin/run.py \
     --config "$ND_PRODUCTION_SPINE_CONFIG" \
@@ -32,4 +30,4 @@ run python3 install/spine/bin/run.py \
 
 infOutDir=${outDir}/MLRECO_SPINE/${subDir}
 mkdir -p "$infOutDir"
-mv "$actualOutFile" "$infOutDir/$(basename "$outFile")"
+mv "$outFile" "$infOutDir/"

--- a/run-mlreco/run_spine.spine-prod.sh
+++ b/run-mlreco/run_spine.spine-prod.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+export ND_PRODUCTION_CONTAINER=${ND_PRODUCTION_CONTAINER:-deeplearnphysics/larcv2:ub2204-cu124-torch251-larndsim}
+
+source ../util/reload_in_container.inc.sh
+source ../util/init.inc.sh
+
+source load_mlreco.inc.sh
+
+# Only export onwards if the vars are filled. The exports are a tip from Kazu and
+# required for NDLAr.
+[ -n "$ND_PRODUCTION_SPINE_NUM_THREADS" ] && export NUM_THREADS=$ND_PRODUCTION_SPINE_NUM_THREADS
+[ -n "$ND_PRODUCTION_SPINE_OPENBLAS_NUM_THREADS" ] && export OPENBLAS_NUM_THREADS=$ND_PRODUCTION_SPINE_OPENBLAS_NUM_THREADS
+
+outFile=${tmpOutDir}/${outName}.MLRECO_SPINE.hdf5
+inName=${ND_PRODUCTION_IN_NAME}.${globalIdx}
+inFile=${ND_PRODUCTION_OUTDIR_BASE}/run-mlreco/${ND_PRODUCTION_IN_NAME}/LARCV/${subDir}/${inName}.LARCV.root
+
+source install/spine-prod/configure.sh
+
+# spine does something interesting with the output filename
+actualOutFile=${tmpOutDir}/${inName}.LARCV_$(basename "$outFile" .hdf5).h5
+
+rm -f "$actualOutFile"
+
+run python3 install/spine/bin/run.py \
+    --config "$ND_PRODUCTION_SPINE_CONFIG" \
+    --log-dir "$logDir" \
+    --source "$inFile" \
+    --output "$outFile"
+
+
+infOutDir=${outDir}/MLRECO_SPINE/${subDir}
+mkdir -p "$infOutDir"
+mv "$actualOutFile" "$infOutDir/$(basename "$outFile")"


### PR DESCRIPTION
This adds a new script `run_spine.spine-prod.sh` that sources spine-prod's `configure.sh` (so that included yamls are properly found, etc.).

The new script does away with the temp-dir creation / template substitution complexity of the old script, since it is no longer necessary with modern configs.

The interpretation of `ND_PRODUCTION_SPINE_CONFIG` is simplified: It's just the path relative to `run-mlreco`; no more magic. So if you want to use a config from `spine-prod`, it'll look like `install/spine-prod/...`. If you want to use a config maintained within ND_Production, it'll start with `configs/...`.

Also, this catches up with SPINE's ongoing campaign to replace underscores with hyphens. A symlink from `spine-prod` to `spine_prod` is created to ensure backward compatibility.

Addresses #76

TODO:
- [x] Verify that SPINE's output filename mangling scheme is consistent. I have only tested this with one SPINE config so far (the "ND-LAr truth matching" config used in some of the recent samples for charge-readout studies). **Confirmed with `infer/nd-lar/full_chain_260310.yaml`**