### PR TITLE
Add ND_PRODUCTION_GENIE_NU_FLAVORS

### DIFF
--- a/run-genie/run_genie.sh
+++ b/run-genie/run_genie.sh
@@ -40,9 +40,15 @@ pushd "$tmpDir"
 
 rm -f "$genieOutPrefix".*
 
+fluxArgs="$dk2nuFile,$ND_PRODUCTION_DET_LOCATION"
+
+if [ -n "$ND_PRODUCTION_GENIE_NU_FLAVORS" ]; then
+    fluxArgs="$fluxArgs,$ND_PRODUCTION_GENIE_NU_FLAVORS"
+fi
+
 args_gevgen_fnal=( \
     -e "$ND_PRODUCTION_EXPOSURE" \
-    -f "$dk2nuFile,$ND_PRODUCTION_DET_LOCATION" \
+    -f "$fluxArgs" \
     -g "$geomFile" \
     -r "$runNo" \
     -L cm -D g_cm3 \


### PR DESCRIPTION
This adds support in `run_genie.sh` for selecting particular neutrino flavors by setting `ND_PRODUCTION_GENIE_NU_FLAVORS` to a comma-separated list of PDG codes. For example, if you want only electron (anti)neutrinos, set it to `12,-12`. If this variable is unset, you'll continue to get all flavors.