### PR TITLE
Add ND_PRODUCTION_CHERRYPICKER_SCRIPT

### DIFF
--- a/run-edep-sim/run_edep_sim.sh
+++ b/run-edep-sim/run_edep_sim.sh
@@ -24,6 +24,13 @@ else
     exit 1
 fi
 
+if [[ -n "$ND_PRODUCTION_CHERRYPICKER_SCRIPT" ]]; then
+    origInputFile=$inputFile
+    inputFile=$tmpOutDir/$(basename "$inputFile" .root).PICKED.root
+    rm -f "$inputFile"
+    python3 "$ND_PRODUCTION_CHERRYPICKER_SCRIPT" -i "$origInputFile" -o "$inputFile"
+fi
+
 edepCode=()
 
 if [[ -n "$inputFile" ]]; then
@@ -56,3 +63,7 @@ run edep-sim -C -g "$ND_PRODUCTION_GEOM_EDEP" -o "$edepRootFile" -e "$nEvents" \
 
 mkdir -p "$outDir/EDEPSIM/$subDir"
 mv "$edepRootFile" "$outDir/EDEPSIM/$subDir"
+
+if [[ -n "$ND_PRODUCTION_CHERRYPICKER_SCRIPT" ]]; then
+    rm "$inputFile"
+fi

--- a/run-edep-sim/run_edep_sim.sh
+++ b/run-edep-sim/run_edep_sim.sh
@@ -34,7 +34,7 @@ if [[ -n "$ND_PRODUCTION_CHERRYPICKER_SCRIPT" ]]; then
     origInputFile=$inputFile
     inputFile=$tmpOutDir/$(basename "$inputFile" .root).PICKED.root
     rm -f "$inputFile"
-    python3 "$ND_PRODUCTION_CHERRYPICKER_SCRIPT" -i "$origInputFile" -o "$inputFile"
+    run python3 "$ND_PRODUCTION_CHERRYPICKER_SCRIPT" -i "$origInputFile" -o "$inputFile"
 fi
 
 edepCode=()

--- a/run-edep-sim/run_edep_sim.sh
+++ b/run-edep-sim/run_edep_sim.sh
@@ -6,6 +6,7 @@ source ../util/reload_in_container.inc.sh
 source ../util/init.inc.sh
 
 simulation=${ND_PRODUCTION_SIM:-GENIE}
+inputFile=""
 
 if [[ "$simulation" == "GENIE" ]]; then
     inputPrefix=${ND_PRODUCTION_OUTDIR_BASE}/run-genie/${ND_PRODUCTION_GENIE_NAME}/GTRAC/$subDir/${ND_PRODUCTION_GENIE_NAME}.$globalIdx
@@ -25,6 +26,11 @@ else
 fi
 
 if [[ -n "$ND_PRODUCTION_CHERRYPICKER_SCRIPT" ]]; then
+    if [[ -z "$inputFile" ]]; then
+        echo "\$ND_PRODUCTION_CHERRYPICKER_SCRIPT can only be used when edep-sim " \
+            "takes an input file (e.g. from GENIE or CORSIKA)"
+        exit 1
+    fi
     origInputFile=$inputFile
     inputFile=$tmpOutDir/$(basename "$inputFile" .root).PICKED.root
     rm -f "$inputFile"


### PR DESCRIPTION
This adds support for running a cherrypicking script prior to edep-sim, for example to select a particular event topology as part of an analysis. The `ND_PRODUCTION_CHERRYPICKER_SCRIPT` can be set to the path of any Python script whose command-line interface looks like `-i input.root -o output.root`.

The changes are pretty self-contained and they have been tested, so I'll merge this in 24 hours if no objections come up.