### PR TITLE
85 move globally sequential trackid assignment from spill build to convert2edepsim spill format step

### DIFF
--- a/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
+++ b/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
@@ -86,18 +86,17 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
         int lastSecTrajId = nPrimaryPart;
 
         spill = new TG4Event();
+        spill->RunId = -1; // since we can match the previous files in the chain without using it, and because there can be more RunIds per spill
+        spill->EventId = spillId;
 
         std::map<std::string, std::vector<TG4HitSegment>> SegmentDetectors;
 
         // Loop over each event in a single spill
         for (size_t i = 0; i < eventIds.size(); ++i) {
             edep_tree->GetEntry(entry + i);
-            spill->RunId = -1; // since we can match the previous files in the chain without using it, and because there can be more RunIds per spill
-            spill->EventId = spillId;
 
             // Count the number of primaries, secondaries and trajectories
-            int nPrimaryPartThisEvent = 0;
-            nPrimaryPartThisEvent += edep_evt->Primaries[0].Particles.size();
+            int nPrimaryPartThisEvent = edep_evt->Primaries[0].Particles.size();
             int nTrajectoriesThisEvent = edep_evt->Trajectories.size();
             int nSecondaryPartThisEvent = nTrajectoriesThisEvent - nPrimaryPartThisEvent;
 

--- a/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
+++ b/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
@@ -1,5 +1,11 @@
 #include "TG4Event.h"
 
+// ROOT macro meant to take in input edep-sim files organized as 1 single nu interaction per entry
+// and convert them into edep-sim files organized as spills. 
+// The TrackId assignment is changed following the edep-sim convention: 
+//  - first all primaries, and all the primaries trajectories; then the secondaries, and the secondaries trajectories. 
+//  - TrackIds always increase, i.e. 1st entry 0, 1, 2; 2nd entry 3, 4, 5, etc.
+
 void convert2edepsim_spill_format(std::string const& inFileName, std::string const& outFileName, int runOffset){
 
     TG4Event* edep_evt = nullptr;
@@ -64,6 +70,22 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
         auto spillId = pair.first;
         auto eventIds = pair.second;
 
+        int nPrimaryPart = 0;
+        int nTrajectories = 0;
+        inFile->cd();
+        for (int i = 0; i < eventIds.size(); i++){
+            edep_tree->GetEntry(entry + i);
+            // here (and afterwards) we assume there is just one primary
+            assert(edep_evt->Primaries.size() != 0u && "Multiple interaction vertices in the same event not supported!!");
+
+            auto v = edep_evt->Primaries[0];
+            nPrimaryPart += v.Particles.size();
+            nTrajectories += edep_evt->Trajectories.size();
+        }
+
+        int lastPriTrajId = 0;
+        int lastSecTrajId = nPrimaryPart;
+
         spill = new TG4Event();
 
         std::map<std::string, std::vector<TG4HitSegment>> SegmentDetectors;
@@ -74,24 +96,48 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
             spill->RunId = (edep_evt->RunId) % runOffset;
             spill->EventId = spillId;
 
+            // count the number of primaries, secondaries and trajectories
+            int nPrimaryPartThisEvent = 0;
+            nPrimaryPartThisEvent += edep_evt->Primaries[0].Particles.size();
+            int nTrajectoriesThisEvent = edep_evt->Trajectories.size();
+            int nSecondaryPartThisEvent = nTrajectoriesThisEvent - nPrimaryPartThisEvent;
+
+            // function to update the TrackId as explained in the point (3) at the beginning
+            auto updateTrackId = [lastPriTrajId, lastSecTrajId, nPrimaryPartThisEvent](int &trkId)
+            { trkId = trkId < nPrimaryPartThisEvent ? lastPriTrajId + trkId : lastSecTrajId + trkId - nPrimaryPartThisEvent; };
+
             // interaction vertex
             if (!edep_evt->Primaries.empty()){
                 auto& v = edep_evt->Primaries[0];
                 spill->Primaries.push_back(v);
+                // for (auto &p : spill->Primaries[i].Particles){
+                //     updateTrackId(p.TrackId);
+                // }
             }
 
             // trajectories
             for (auto &t : edep_evt->Trajectories){
                 spill->Trajectories.push_back(t);
+                //updateTrackId(spill->Trajectories.back().TrackId);
+                if (spill->Trajectories.back().ParentId != -1){
+                  //  updateTrackId(spill->Trajectories.back().ParentId);
+                }
             }
 
             // energy depositions
             for (auto &d : edep_evt->SegmentDetectors){
                 for (auto &h : d.second){
                     SegmentDetectors[d.first].push_back(h);
+                    //updateTrackId(SegmentDetectors[d.first].back().PrimaryId);
+                    for (auto &trkId : SegmentDetectors[d.first].back().Contrib){
+                      //  updateTrackId(trkId);
+                    }
                 }
             }
-        }// end loop over events of the same spillId
+            
+            lastPriTrajId += nPrimaryPartThisEvent;
+            lastSecTrajId += nSecondaryPartThisEvent;
+    }// end loop over events of the same spillId
     entry += eventIds.size();
     spill->SegmentDetectors = std::vector<std::pair<std::string, std::vector<TG4HitSegment>>>(SegmentDetectors.begin(), SegmentDetectors.end());
     outTree->Fill();

--- a/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
+++ b/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
@@ -1,12 +1,14 @@
 #include "TG4Event.h"
 
 // ROOT macro meant to take in input edep-sim files organized as 1 single nu interaction per entry
-// and convert them into edep-sim files organized as spills. 
-// The TrackId assignment is changed following the edep-sim convention: 
-//  - first all primaries, and all the primaries trajectories; then the secondaries, and the secondaries trajectories. 
+// and convert them into edep-sim files organized as spills.
+// The TrackId assignment is changed following the edep-sim convention:
+//  - first all primaries, and all the primaries trajectories; then the secondaries, and the
+//    secondaries trajectories.
 //  - TrackIds always increase, i.e. 1st entry 0, 1, 2; 2nd entry 3, 4, 5, etc.
 
-void convert2edepsim_spill_format(std::string const& inFileName, std::string const& outFileName, int runOffset){
+void convert2edepsim_spill_format(std::string const& inFileName, std::string const& outFileName,
+                                   int runOffset) {
 
     TG4Event* edep_evt = nullptr;
     TG4Event* spill = nullptr;
@@ -16,7 +18,7 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
     std::unique_ptr<TTree> edep_tree(inFile->Get<TTree>("EDepSimEvents"));
     edep_tree->SetBranchAddress("Event", &edep_evt);
     std::unique_ptr<TTree> in_genie_tree(inFile->Get<TTree>("DetSimPassThru/gRooTracker"));
-    auto geom = (TGeoManager*) inFile->Get("EDepSimGeometry");
+    auto* geom = static_cast<TGeoManager*>(inFile->Get("EDepSimGeometry"));
 
     // output files (GENIE tree is just a copy of the input)
     std::unique_ptr<TFile> outFile(TFile::Open(outFileName.c_str(), "RECREATE"));
@@ -27,57 +29,54 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
         outFile->cd();
         out_genie_tree = in_genie_tree->CloneTree(-1, "fast");
     }
-    
-    TMap* input_map = (TMap*)inFile->Get("event_spill_map");
 
-    // create a map to match the eventIds with the corresponding spillId
+    auto* input_map = static_cast<TMap*>(inFile->Get("event_spill_map"));
+
+    // Create a map to match the eventIds with the corresponding spillId
     std::map<int, std::vector<int>> spill_event_map;
 
-    // loop over the entries to read the spillId from the TMap
-    for (int i = 0; i < edep_tree->GetEntries(); i++){ 
+    // Loop over the entries to read the spillId from the TMap
+    for (std::size_t i{}, entries = edep_tree->GetEntries(); i != entries; ++i) {
 
         edep_tree->GetEntry(i);
 
-        // take the map and get the spillId
-        std::string event_string = std::to_string(edep_evt->RunId) + " "
-        + std::to_string(edep_evt->EventId); 
+        // Take the map and get the spillId
+        auto event_string = std::to_string(edep_evt->RunId) + " " +
+                            std::to_string(edep_evt->EventId);
         TObjString event_tobj(event_string.c_str());
 
-        auto spillId_obj = input_map->GetValue(&event_tobj);
-        if (!spillId_obj){
-            std::cerr << "Warning: No spill ID found for event " << event_string << std::endl;
-            continue;
+        auto* spillId_obj = input_map->GetValue(&event_tobj);
+        if (spillId_obj == nullptr) {
+            throw std::runtime_error("Spill ID not found for event " + event_string);
+            return;
         }
 
         auto* spillIdStr = dynamic_cast<TObjString*>(spillId_obj);
-        if (!spillIdStr) {
-            std::cerr << "Error: Invalid spill ID object for event " << event_string << std::endl;
-            continue;
+        if (spillIdStr == nullptr) {
+            throw std::runtime_error("Spill ID not found for event " + event_string);
+            return;
         }
 
         auto spillId = std::atoi(spillIdStr->GetString());
 
-        // fill the map assigning the eventIds to the corresponding spillId
+        // Fill the map assigning the eventIds to the corresponding spillId
         spill_event_map[spillId].push_back(edep_evt->EventId);
     }
 
-    // useful to keep track of the number of the entry 
-    // I need from the edep_tree
+    // Useful to keep track of the number of entries needed from the edep_tree
     int entry = 0;
 
-    // loop over the map: for each spillId I loop over all the events
-    for (auto &pair : spill_event_map){
+    // Loop over the map: for each spillId loop over all the events
+    for (auto const& pair : spill_event_map) {
         auto spillId = pair.first;
         auto eventIds = pair.second;
 
         int nPrimaryPart = 0;
         int nTrajectories = 0;
-        inFile->cd();
-        for (int i = 0; i < eventIds.size(); i++){
-            edep_tree->GetEntry(entry + i);
-            // here (and afterwards) we assume there is just one primary
-            assert(edep_evt->Primaries.size() != 0u && "Multiple interaction vertices in the same event not supported!!");
 
+        for (int i = 0; i < eventIds.size(); ++i) {
+            edep_tree->GetEntry(entry + i);
+            // Assume there is just one primary
             auto v = edep_evt->Primaries[0];
             nPrimaryPart += v.Particles.size();
             nTrajectories += edep_evt->Trajectories.size();
@@ -90,59 +89,68 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
 
         std::map<std::string, std::vector<TG4HitSegment>> SegmentDetectors;
 
-        // loop over each event in a single spill
-        for (size_t i = 0; i < eventIds.size(); i++){
+        // Loop over each event in a single spill
+        for (size_t i = 0; i < eventIds.size(); ++i) {
             edep_tree->GetEntry(entry + i);
             spill->RunId = (edep_evt->RunId) % runOffset;
             spill->EventId = spillId;
 
-            // count the number of primaries, secondaries and trajectories
+            // Count the number of primaries, secondaries and trajectories
             int nPrimaryPartThisEvent = 0;
             nPrimaryPartThisEvent += edep_evt->Primaries[0].Particles.size();
             int nTrajectoriesThisEvent = edep_evt->Trajectories.size();
             int nSecondaryPartThisEvent = nTrajectoriesThisEvent - nPrimaryPartThisEvent;
 
-            // function to update the TrackId as explained in the point (3) at the beginning
-            auto updateTrackId = [lastPriTrajId, lastSecTrajId, nPrimaryPartThisEvent](int &trkId)
-            { trkId = trkId < nPrimaryPartThisEvent ? lastPriTrajId + trkId : lastSecTrajId + trkId - nPrimaryPartThisEvent; };
+            // Function to update the TrackId as explained at the beginning
+            auto updateTrackId = [lastPriTrajId, lastSecTrajId, nPrimaryPartThisEvent](
+                int& trkId) {
+                trkId = trkId < nPrimaryPartThisEvent
+                            ? lastPriTrajId + trkId
+                            : lastSecTrajId + trkId - nPrimaryPartThisEvent;
+            };
 
-            // interaction vertex
-            if (!edep_evt->Primaries.empty()){
+            // Interaction vertex
+            if (!edep_evt->Primaries.empty()) {
                 auto& v = edep_evt->Primaries[0];
                 spill->Primaries.push_back(v);
-                // for (auto &p : spill->Primaries[i].Particles){
-                //     updateTrackId(p.TrackId);
-                // }
+                for (auto& p : spill->Primaries.back().Particles) {
+                    updateTrackId(p.TrackId);
+                }
+            } else {
+                throw std::runtime_error(
+                    "No primary vertices found, skipping vertex information");
             }
 
-            // trajectories
-            for (auto &t : edep_evt->Trajectories){
+            // Trajectories
+            for (auto& t : edep_evt->Trajectories) {
                 spill->Trajectories.push_back(t);
-                //updateTrackId(spill->Trajectories.back().TrackId);
-                if (spill->Trajectories.back().ParentId != -1){
-                  //  updateTrackId(spill->Trajectories.back().ParentId);
+                updateTrackId(spill->Trajectories.back().TrackId);
+                if (spill->Trajectories.back().ParentId != -1) {
+                    updateTrackId(spill->Trajectories.back().ParentId);
                 }
             }
 
-            // energy depositions
-            for (auto &d : edep_evt->SegmentDetectors){
-                for (auto &h : d.second){
+            // Energy depositions
+            for (auto& d : edep_evt->SegmentDetectors) {
+                for (auto& h : d.second) {
                     SegmentDetectors[d.first].push_back(h);
-                    //updateTrackId(SegmentDetectors[d.first].back().PrimaryId);
-                    for (auto &trkId : SegmentDetectors[d.first].back().Contrib){
-                      //  updateTrackId(trkId);
+                    updateTrackId(SegmentDetectors[d.first].back().PrimaryId);
+                    for (auto& trkId : SegmentDetectors[d.first].back().Contrib) {
+                        updateTrackId(trkId);
                     }
                 }
             }
-            
+
             lastPriTrajId += nPrimaryPartThisEvent;
             lastSecTrajId += nSecondaryPartThisEvent;
-    }// end loop over events of the same spillId
-    entry += eventIds.size();
-    spill->SegmentDetectors = std::vector<std::pair<std::string, std::vector<TG4HitSegment>>>(SegmentDetectors.begin(), SegmentDetectors.end());
-    outTree->Fill();
-    delete spill;
-    }// end loop over spills
+        }
+
+        entry += eventIds.size();
+        spill->SegmentDetectors = std::vector<std::pair<std::string, std::vector<TG4HitSegment>>>(
+            SegmentDetectors.begin(), SegmentDetectors.end());
+        outTree->Fill();
+        delete spill;
+    }
 
     outFile->cd();
     outTree->Write();
@@ -150,7 +158,7 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
 
     outFile->mkdir("DetSimPassThru");
     outFile->cd("DetSimPassThru");
-    if (out_genie_tree){
+    if (out_genie_tree) {
         out_genie_tree->Write();
     }
 

--- a/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
+++ b/run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp
@@ -92,7 +92,7 @@ void convert2edepsim_spill_format(std::string const& inFileName, std::string con
         // Loop over each event in a single spill
         for (size_t i = 0; i < eventIds.size(); ++i) {
             edep_tree->GetEntry(entry + i);
-            spill->RunId = (edep_evt->RunId) % runOffset;
+            spill->RunId = -1; // since we can match the previous files in the chain without using it, and because there can be more RunIds per spill
             spill->EventId = spillId;
 
             // Count the number of primaries, secondaries and trajectories

--- a/run-spill-build/overlaySinglesIntoSpillsSortedWithNuIntTime.cpp
+++ b/run-spill-build/overlaySinglesIntoSpillsSortedWithNuIntTime.cpp
@@ -21,9 +21,6 @@
 //   (2) The timing information is edited to impose the timing microstructure of
 //       the LBNF beamline, the neutrino parent time of flight, the neutrino time of flight 
 //       and the "macrostructure" (spill period).
-//   
-//   (3) The TrackId follows the edep-sim convention: first all primaries, and all the primaries
-//       trajectories; then the secondaries, and the secondaries trajectories
 
 constexpr long double conversionTo_ns = 1.E9; 
 constexpr long double c = TMath::C() / conversionTo_ns; // [m/ns]
@@ -355,25 +352,11 @@ void overlaySinglesIntoSpillsSortedWithNuIntTime(
       gRooTracker& genie_evt = is_sampleA ? genie_evts_A_data : genie_evts_B_data;
 
       times[i] = TaggedTime(getInteractionTime_LBNF(*dk2nu_evt, genie_evt, flux), is_sampleA, is_sampleA ? evt_it + i : evt_it_B_sequence.at(evt_it + i - Nevts_this_spill_A));
-
-      // needed to count the the number of primary particles and trajectories, 
-      // (referred to point (3) at the beginning). We select just the first entry since
-      // we have always a single interaction (one interaction vertex)
-      auto v = edep_evt->Primaries[0];
-      nPrimaryPart += v.Particles.size();
-      nTrajectories += edep_evt->Trajectories.size();
     }
     
     std::sort(times.begin(),
               times.end(),
               [](const auto& lhs, const auto& rhs) { return lhs.time < rhs.time; });
-
-    std::cout << "This spill: " << std::endl;
-    std::cout << "  - Primary particle: " << nPrimaryPart << std::endl;
-    std::cout << "  - Trajectories    : " << nTrajectories << std::endl;
-
-    int lastPriTrajId = 0;
-    int lastSecTrajId = nPrimaryPart;
 
     // loop on times vector: different from overlaySingleIntoSpillsSorted.cpp!
     // there, the first time is associated with the first event
@@ -415,16 +398,6 @@ void overlaySinglesIntoSpillsSortedWithNuIntTime(
       genie_tree_data.EvtNum = edep_evt->EventId;
       genie_tree_data.EvtVtx[3] = event_time;
 
-      // count the number of primaries, secondaries and trajectories
-      int nPrimaryPartThisEvent = 0;
-      nPrimaryPartThisEvent += edep_evt->Primaries[0].Particles.size();
-      int nTrajectoriesThisEvent = edep_evt->Trajectories.size();
-      int nSecondaryPartThisEvent = nTrajectoriesThisEvent - nPrimaryPartThisEvent;
-
-      // function to update the TrackId as explained in the point (3) at the beginning
-      auto updateTrackId = [lastPriTrajId, lastSecTrajId, nPrimaryPartThisEvent](int &trkId)
-      { trkId = trkId < nPrimaryPartThisEvent ? lastPriTrajId + trkId : lastSecTrajId + trkId - nPrimaryPartThisEvent; };
-
       // assign the correct time to the vertex, the trajectories and the energy depositions
       // ... interaction vertex
       auto& v = edep_evt->Primaries[0];
@@ -436,9 +409,6 @@ void overlaySinglesIntoSpillsSortedWithNuIntTime(
       // trivially set InteractionNumber to be the current entry number.
       // https://github.com/DUNE/2x2_sim/issues/54
       v.InteractionNumber = evt_it_A + evt_it_B;
-      for (auto &p : v.Particles){
-        updateTrackId(p.TrackId);
-      }
 
 
       // ... trajectories
@@ -447,10 +417,6 @@ void overlaySinglesIntoSpillsSortedWithNuIntTime(
         for (std::vector<TG4TrajectoryPoint>::iterator p = t->Points.begin(); p != t->Points.end(); ++p) {
           double offset = p->Position.T() - old_event_time;
           p->Position.SetT(event_time + offset);
-        }
-        updateTrackId(t->TrackId);
-        if (t->ParentId != -1){
-          updateTrackId(t->ParentId);
         }
       }
 
@@ -461,15 +427,8 @@ void overlaySinglesIntoSpillsSortedWithNuIntTime(
           double stop_offset = h->Stop.T() - old_event_time;
           h->Start.SetT(event_time + start_offset);
           h->Stop.SetT(event_time + stop_offset);
-          updateTrackId(h->PrimaryId);
-          for (auto &trkId : h->Contrib){
-            updateTrackId(trkId);
-          }
         }
       }
-
-      lastPriTrajId += nPrimaryPartThisEvent;
-      lastSecTrajId += nSecondaryPartThisEvent;
 
       new_tree->Fill();
       genie_tree->Fill();


### PR DESCRIPTION
Moved TrackId assignment logic from run-spill-build/overlayScripts/overlaySinglesIntoSpillsSortedWithNuIntTime.cpp to run-convert2edepsim-spill-format/convert2edepsim_spill_format.cpp