### PR TITLE
`run-cafmaker`: Source the correct version of the `ndcaf_setup.sh` script

### DIFF
--- a/run-cafmaker/run_cafmaker.sh
+++ b/run-cafmaker/run_cafmaker.sh
@@ -4,11 +4,9 @@ export ND_PRODUCTION_CONTAINER=${ND_PRODUCTION_CONTAINER:-fermilab/fnal-wn-sl7:l
 
 source ../util/reload_in_container.inc.sh
 
-cd install/ND_CAFMaker
 set +o errexit
-source ndcaf_setup.sh
+source install/ND_CAFMaker/install/bin/ndcaf_setup.sh prof
 set -o errexit
-cd ../..
 
 # Must go after ndcaf_setup.sh
 source ../util/init.inc.sh
@@ -46,7 +44,7 @@ cat "$cfgFile"
 echo ""
 echo ===================
 
-run install/ND_CAFMaker/install/bin/makeCAF "--fcl=$cfgFile"
+run makeCAF "--fcl=$cfgFile"
 
 cafOutDir=$outDir/CAF/$subDir
 flatCafOutDir=$outDir/CAF.flat/$subDir


### PR DESCRIPTION
and remove a couple of unnecessary line. Fixes the issue discussed here.

- [x] I've checked the `FHICL_FILE_PATH`, `LD_LIBRARY_PATH` and which `makeCAF` is actually getting called and all looks as expected (see below). 
- [x] @jacoblarkin, can you test this in your set-up to make sure things actually run? I am not set up with all the inputs to do that easily.

```
> ./run_cafmaker.sh 

The following have been reloaded with a version change:
  1) cudatoolkit/12.9 => cudatoolkit/12.4

Setting up larsoft UPS area... /cvmfs/larsoft.opensciencegrid.org
Setting up DUNE UPS area... /cvmfs/dune.opensciencegrid.org/products/dune/
which makeCAF
/global/homes/a/abooth/dune/Production/development_repos/ND_Production/run-cafmaker/install/ND_CAFMaker/install/bin/makeCAF

FHICL_FILE_PATH
/global/homes/a/abooth/dune/Production/development_repos/ND_Production/run-cafmaker/install/ND_CAFMaker/install/bin/../cfg:

LD_LIBRARY_PATH
/global/homes/a/abooth/dune/Production/development_repos/ND_Production/run-cafmaker/install/ND_CAFMaker/install/bin/../lib:/cvmfs/dune.opensciencegrid.org/products/dune/duneanaobj/v04_00_00/slf7.x86_64.e26.prof/lib:/lib:/cvmfs/larsoft.opensciencegrid.org/products/fhiclcpp/v4_18_04/slf7.x86_64.e26.prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/tbb/v2021_9_0/Linux64bit+3.10-2.17-e26/lib:/cvmfs/larsoft.opensciencegrid.org/products/cetlib/v3_18_02/slf7.x86_64.e26.prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/sqlite/v3_40_01_00/Linux64bit+3.10-2.17/lib:/cvmfs/larsoft.opensciencegrid.org/products/cetlib_except/v1_09_01/slf7.x86_64.e26.prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/gcc/v12_1_0/Linux64bit+3.10-2.17/lib64:/cvmfs/larsoft.opensciencegrid.org/products/gcc/v12_1_0/Linux64bit+3.10-2.17/lib:/cvmfs/larsoft.opensciencegrid.org/products/boost/v1_82_0/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/hdf5/v1_12_2b/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/dune.opensciencegrid.org/products/dune/duneanaobj/v04_00_00/slf7.x86_64.e26.prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/scitokens_cpp/v1_0_1a/Linux64bit+3.10-2.17-e26-sql34001/lib:/cvmfs/larsoft.opensciencegrid.org/products/xrootd/v5_5_5a/Linux64bit+3.10-2.17-e26-p3915-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/pythia/v6_4_28x/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/postgresql/v15_3/Linux64bit+3.10-2.17-p3915/lib:/cvmfs/larsoft.opensciencegrid.org/products/openblas/v0_3_23/Linux64bit+3.10-2.17-e26/lib:/cvmfs/larsoft.opensciencegrid.org/products/python/v3_9_15/Linux64bit+3.10-2.17/lib:/cvmfs/larsoft.opensciencegrid.org/products/protobuf/v3_21_12a/Linux64bit+3.10-2.17-e26/lib:/cvmfs/larsoft.opensciencegrid.org/products/libxml2/v2_9_12/Linux64bit+3.10-2.17/lib:/cvmfs/larsoft.opensciencegrid.org/products/gsl/v2_7/Linux64bit+3.10-2.17/lib:/cvmfs/larsoft.opensciencegrid.org/products/fftw/v3_3_10/Linux64bit+3.10-2.17/lib:/cvmfs/larsoft.opensciencegrid.org/products/root/v6_28_12/Linux64bit+3.10-2.17-e26-p3915-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/dk2nudata/v01_10_01h/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/log4cpp/v1_1_3e/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/lhapdf/v6_5_4/Linux64bit+3.10-2.17-e26-p3915-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/genie/v3_04_00i/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/dk2nugenie/v01_10_01p/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/larsoft.opensciencegrid.org/products/geant4/v4_10_6_p01g/Linux64bit+3.10-2.17-e26-prof/lib64:/cvmfs/larsoft.opensciencegrid.org/products/xerces_c/v3_2_3e/Linux64bit+3.10-2.17-e26/lib:/cvmfs/larsoft.opensciencegrid.org/products/clhep/v2_4_7_1/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/dune.opensciencegrid.org/products/dune/./edepsim/v3_2_0e/Linux64bit+3.10-2.17-e26-prof/lib:/cvmfs/fermilab.opensciencegrid.org/products/common/db//../prd/curl/v7_64_1/Linux64bit-3-10/lib:/cvmfs/fermilab.opensciencegrid.org/products/common/db//../prd/pycurl/v7_19_5_3/Linux64bit-3-10/lib:/cvmfs/larsoft.opensciencegrid.org/products/gmp/v6_2_1/Linux64bit+3.10-2.17/lib:/global/common/software/dune/cuda-23.9/math_libs/12.2/targets/x86_64-linux/lib:/global/common/software/dune/cuda-23.9/cuda/12.2/lib64:/opt/udiImage/modules/gpu/lib64
```