### PR TITLE
Set OMP_NUM_THREADS for flow2supera

### DIFF
--- a/run-mlreco/run_flow2supera.data.sh
+++ b/run-mlreco/run_flow2supera.data.sh
@@ -17,6 +17,7 @@ config=$ND_PRODUCTION_FLOW2SUPERA_CONFIG
 
 rm -f "$outFile"
 
+export OMP_NUM_THREADS=${ND_PRODUCTION_OMP_NUM_THREADS:-1}
 run install/flow2supera/bin/run_flow2supera.py -o "$outFile" -c "$config" "$inFile"
 
 mv "${outFile}" "${outDir}"

--- a/run-mlreco/run_flow2supera.sh
+++ b/run-mlreco/run_flow2supera.sh
@@ -14,6 +14,7 @@ config=$ND_PRODUCTION_FLOW2SUPERA_CONFIG
 
 rm -f "$outFile"
 
+export OMP_NUM_THREADS=${ND_PRODUCTION_OMP_NUM_THREADS:-1}
 run install/flow2supera/bin/run_flow2supera.py -o "$outFile" -c "$config" "$inFile"
 
 larcvOutDir=$outDir/LARCV/$subDir


### PR DESCRIPTION
When flow2supera runs DBSCAN, it spawns a bunch of threads. The threading doesn't seem to benefit performance, and it greatly limits the number of parallel flow2supera processes that can be run before everything slows to a crawl. Setting `OMP_NUM_THREADS` to 1 doesn't slow down flow2supera much (if it all) in my experience, and allows every core to be used efficiently for its own flow2supera process.