### PR TITLE
ghep tree takes the entry corresponding to the EventId

### DIFF
--- a/run-spill-build/overlaySinglesIntoSpillsSortedWithNuIntTime.cpp
+++ b/run-spill-build/overlaySinglesIntoSpillsSortedWithNuIntTime.cpp
@@ -347,7 +347,7 @@ void overlaySinglesIntoSpillsSortedWithNuIntTime(
       auto entry = is_sampleA ? evt_it + i : evt_it_B_sequence.at(evt_it + i - Nevts_this_spill_A);
       in_tree->GetEntry(entry);
       gn_tree->GetEntry(entry);
-      ghep_tree->GetEntry(entry);
+      ghep_tree->GetEntry(edep_evt->EventId);
 
       gRooTracker& genie_evt = is_sampleA ? genie_evts_A_data : genie_evts_B_data;
 


### PR DESCRIPTION
The EDEPSIM step takes just the events with hits, as in the .mac files there is the condition: `/edep/db/set/requireEventsWithHits` true. This could lead to have less events in the edep files with respect to the ghep ones (gtrac files instead are copied into edep files maintaining a 1-1 correspondence). This possible mismatch could be a problem in the spill-build step: when the interaction time is computed, flux information from the ghep files are taken, so we need to have the right correspondence between edep and ghep files.
With this PR I have just changed a line in the spill-build code: instead of taking the entry I take the corresponding EventId